### PR TITLE
fix: withdraw fund logic

### DIFF
--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -294,7 +294,6 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
 
         uint256 drawableFunds_ = loan_.drawableFunds;
 
-
         loan_.drawableFunds = 0;
 
         IERC721(loan_.receivableAsset).safeTransferFrom(msg.sender, address(this), loan_.receivableTokenId);

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -284,7 +284,7 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
     }
 
     /// @inheritdoc ILoanManager
-    function withdrawFunds(uint16 loanId_, address destination_, uint256 amount_) external override whenNotPaused {
+    function withdrawFunds(uint16 loanId_, address destination_) external override whenNotPaused {
         Loan.Info memory loan_ = _loans[loanId_];
 
         // Only the seller can drawdown funds
@@ -292,15 +292,10 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
             revert Errors.LoanManager_CallerNotSeller({ expectedSeller_: loan_.seller });
         }
 
-        if (amount_ > loan_.drawableFunds) {
-            revert Errors.LoanManager_Overdraw({
-                loanId_: loanId_,
-                amount_: amount_,
-                withdrawableAmount_: loan_.drawableFunds
-            });
-        }
+        uint256 drawableFunds_ = loan_.drawableFunds;
 
-        loan_.drawableFunds -= amount_;
+
+        loan_.drawableFunds = 0;
 
         IERC721(loan_.receivableAsset).safeTransferFrom(msg.sender, address(this), loan_.receivableTokenId);
 
@@ -309,9 +304,9 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
             IReceivable(loan_.receivableAsset).burnReceivable(loan_.receivableTokenId);
         }
 
-        IERC20(asset).safeTransfer(destination_, amount_);
+        IERC20(asset).safeTransfer(destination_, drawableFunds_);
 
-        emit FundsWithdrawn({ loanId_: loanId_, amount_: amount_ });
+        emit FundsWithdrawn({ loanId_: loanId_, amount_: drawableFunds_ });
     }
 
     /// @inheritdoc ILoanManager

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -285,7 +285,7 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
 
     /// @inheritdoc ILoanManager
     function withdrawFunds(uint16 loanId_, address destination_) external override whenNotPaused {
-        Loan.Info memory loan_ = _loans[loanId_];
+        Loan.Info storage loan_ = _loans[loanId_];
 
         // Only the seller can drawdown funds
         if (msg.sender != loan_.seller) {

--- a/contracts/interfaces/ILoanManager.sol
+++ b/contracts/interfaces/ILoanManager.sol
@@ -111,6 +111,5 @@ interface ILoanManager is ILoanManagerEvents, ILoanManagerStorage {
     /// @notice Used by sellers to withdraw funds from a loan.
     /// @param loanId_ Id of the loan to withdraw funds from
     /// @param destination_ The destination address for the funds
-    /// @param amount_ The amount to withdraw
-    function withdrawFunds(uint16 loanId_, address destination_, uint256 amount_) external;
+    function withdrawFunds(uint16 loanId_, address destination_) external;
 }

--- a/scripts/Init.s.sol
+++ b/scripts/Init.s.sol
@@ -140,7 +140,7 @@ contract Init is BaseScript {
 
             IERC721(info_.receivableAsset).approve(address(loanManager_), info_.receivableTokenId);
 
-            loanManager_.withdrawFunds({ loanId_: loanIds_[i], destination_: seller, amount_: info_.drawableFunds });
+            loanManager_.withdrawFunds({ loanId_: loanIds_[i], destination_: seller });
         }
     }
 }

--- a/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
@@ -84,7 +84,7 @@ contract RepayLoan_LoanManager_Integration_Concrete_Test is
 
         changePrank(users.seller);
         receivable.approve(address(loanManager), defaults.RECEIVABLE_TOKEN_ID());
-        loanManager.withdrawFunds(1, address(users.seller), defaults.PRINCIPAL_REQUESTED());
+        loanManager.withdrawFunds(1, address(users.seller));
 
         vm.warp(defaults.MAY_31_2023());
 

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
@@ -24,9 +24,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         isleGlobals.setContractPaused(address(loanManager), true);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.FunctionPaused.selector, bytes4(keccak256("withdrawFunds(uint16,address)"))
-            )
+            abi.encodeWithSelector(Errors.FunctionPaused.selector, bytes4(keccak256("withdrawFunds(uint16,address)")))
         );
         loanManager.withdrawFunds(1, address(0));
     }
@@ -37,12 +35,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         loanManager.withdrawFunds(1, address(0));
     }
 
-
-    function test_WithdrawFunds_WhenLoanNotRepaid()
-        external
-        whenNotPaused
-        whenCallerSeller
-    {
+    function test_WithdrawFunds_WhenLoanNotRepaid() external whenNotPaused whenCallerSeller {
         uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
         uint256 loanManagerBalanceBefore = usdc.balanceOf(address(loanManager));
 
@@ -59,12 +52,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         assertEq(loanManagerBalanceAfter, loanManagerBalanceBefore - principalRequested);
     }
 
-    function test_WithdrawFunds()
-        external
-        whenNotPaused
-        whenCallerSeller
-        whenLoanRepaid
-    {
+    function test_WithdrawFunds() external whenNotPaused whenCallerSeller whenLoanRepaid {
         changePrank(users.buyer);
         loanManager.repayLoan(1);
 
@@ -97,7 +85,6 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         changePrank(users.seller);
         _;
     }
-
 
     modifier whenLoanRepaid() {
         _;

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
@@ -25,31 +25,23 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.FunctionPaused.selector, bytes4(keccak256("withdrawFunds(uint16,address,uint256)"))
+                Errors.FunctionPaused.selector, bytes4(keccak256("withdrawFunds(uint16,address)"))
             )
         );
-        loanManager.withdrawFunds(1, address(0), 0);
+        loanManager.withdrawFunds(1, address(0));
     }
 
     function test_RevertWhen_CallerNotLoanSeller() external whenNotPaused {
         changePrank(users.eve);
         vm.expectRevert(abi.encodeWithSelector(Errors.LoanManager_CallerNotSeller.selector, users.seller));
-        loanManager.withdrawFunds(1, address(0), 0);
+        loanManager.withdrawFunds(1, address(0));
     }
 
-    function test_RevertWhen_WithdrawAmountGreaterThanDrawableAmount() external whenNotPaused whenCallerSeller {
-        uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.LoanManager_Overdraw.selector, 1, principalRequested + 1, principalRequested)
-        );
-        loanManager.withdrawFunds(1, address(users.seller), principalRequested + 1);
-    }
 
     function test_WithdrawFunds_WhenLoanNotRepaid()
         external
         whenNotPaused
         whenCallerSeller
-        whenWithdrawAmountLessThanOrEqualToDrawableAmount
     {
         uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
         uint256 loanManagerBalanceBefore = usdc.balanceOf(address(loanManager));
@@ -59,7 +51,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         vm.expectEmit(true, true, true, true);
         emit FundsWithdrawn(1, principalRequested);
 
-        loanManager.withdrawFunds(1, address(users.seller), principalRequested);
+        loanManager.withdrawFunds(1, address(users.seller));
 
         uint256 loanManagerBalanceAfter = usdc.balanceOf(address(loanManager));
 
@@ -71,7 +63,6 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         external
         whenNotPaused
         whenCallerSeller
-        whenWithdrawAmountLessThanOrEqualToDrawableAmount
         whenLoanRepaid
     {
         changePrank(users.buyer);
@@ -90,7 +81,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         vm.expectEmit(true, true, true, true);
         emit FundsWithdrawn(1, principalRequested);
 
-        loanManager.withdrawFunds(1, address(users.seller), principalRequested);
+        loanManager.withdrawFunds(1, address(users.seller));
 
         uint256 loanManagerBalanceAfter = usdc.balanceOf(address(loanManager));
 
@@ -107,9 +98,6 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         _;
     }
 
-    modifier whenWithdrawAmountLessThanOrEqualToDrawableAmount() {
-        _;
-    }
 
     modifier whenLoanRepaid() {
         _;

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
@@ -5,16 +5,13 @@ withdrawFunds.t.sol
    ├── when the caller is not the seller
    │  └── it should revert
    └── when the caller is the seller
-      ├── when the withdraw amount is greater than the drawable amount
-      │  └── it should revert
-      └── when the withdraw amount is less than or equal to the drawable amount
-         ├── when the buyer is not repay the loan
-         │  ├── it should transfer the collateral receivable from the seller to the loanManager
-         │  ├── it should transfer the drawable amount from loanManager to the seller
-         │  └── it should emit a {FundsWithdrawn} event
-         └── when the buyer is repay the loan
-            ├── it should transfer the collateral receivable from the seller to the loanManager
-            ├── it should burn the receivable token
-            ├── it should emit a {AssetBurned} event
-            ├── it should transfer the drawable amount from loanManager to the seller
-            └── it should emit a {FundsWithdrawn} event
+      ├── when the buyer is not repay the loan
+      │  ├── it should transfer the collateral receivable from the seller to the loanManager
+      │  ├── it should transfer the drawable amount from loanManager to the seller
+      │  └── it should emit a {FundsWithdrawn} event
+      └── when the buyer is repay the loan
+         ├── it should transfer the collateral receivable from the seller to the loanManager
+         ├── it should burn the receivable token
+         ├── it should emit a {AssetBurned} event
+         ├── it should transfer the drawable amount from loanManager to the seller
+         └── it should emit a {FundsWithdrawn} event


### PR DESCRIPTION
# Summary
In the initial design, the supplier could pass amount as a parameter to withdraw funds through `LoanManager::withdrawFunds`. If the withdrawal amount was less than the `loan_.drawableFunds` value, the `LoanManager` would still call `transferFrom` and transfer the `Receivable` NFT from the supplier to the `LoanManager`. Consequently, the supplier would be unable to withdraw the remaining funds, as the ERC-721 transfer would fail on subsequent attempts.

This PR analyzes the current design and fixes this logic flaw.

# Description

After careful analysis, we first removed the amount parameter from `LoanManager::withdrawFunds`. Now, each call to this function withdraws all drawable funds according to the loan information.

Subsequently, we removed the verification of pool asset amounts, as it is impossible for the `LoanManager` to have insufficient assets to transfer to the supplier.

Considering the current protocol design, whether buyers repay the loan, lenders request `redeem`/`redeem`, or any other operation occurs, the `LoanManager` will always have sufficient pool assets. This is because the funds are transferred from the `Pool` through `LoanManager::fundLoan`, and no roles can remove the liquidity from the contract.

# Verification

`forge test --mc WithdrawFunds_LoanManager_Integration_Concrete_Test`
