### PR TITLE
fix: reset isImpaired to false when remove loan impairment

### DIFF
--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -417,6 +417,7 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
         }
 
         _loans[loanId_].dueDate = originalDueDate_;
+        _loans[loanId_].isImpaired = false;
         delete _loans[loanId_].originalDueDate;
 
         emit ImpairmentRemoved(loanId_, originalDueDate_);

--- a/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
+++ b/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
@@ -81,6 +81,22 @@ contract TriggerDefault_LoanManager_Integration_Concrete_Test is
         loanManager.triggerDefault(1);
     }
 
+    function test_TriggerDefault_WhenLoanRemoveImpair()
+        external
+        whenNotPaused
+        whenBlockTimestampGreaterThanDueDatePlusGracePeriod
+        whenPaymentIdIsNotZero
+    {
+        // Remove an impaired loan and make sure interests and remainingLosses are
+        // correct after the `isImpaired` flag set back to false
+        changePrank(users.governor);
+        loanManager.impairLoan(1);
+        loanManager.removeLoanImpairment(1);
+
+        changePrank(address(poolConfigurator));
+        triggerDefault();
+    }
+
     function test_TriggerDefault()
         external
         whenNotPaused
@@ -88,6 +104,10 @@ contract TriggerDefault_LoanManager_Integration_Concrete_Test is
         whenBlockTimestampGreaterThanDueDatePlusGracePeriod
         whenPaymentIdIsNotZero
     {
+        triggerDefault();
+    }
+
+    function triggerDefault() internal {
         // 10 days late = 30 days + (7 days grace period + 2 days + 1s)
         vm.warp(defaults.MAY_31_2023() + defaults.GRACE_PERIOD() + 2 days + 1);
 


### PR DESCRIPTION
# Summary
Inconsistent Loan Impairment Handling Due to Missing Reset of isImpaired Flag

[Issue](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e#ac0228e633b94fe382b96bfc9383dfeb)

# Description
The removeLoanImpairment function in the LoanManager contract fails to reset the isImpaired flag to false after removing a loan's impairment. As a result, the loan remains incorrectly marked as impaired, leading to inconsistencies in how the loan is managed by the contract. This can cause incorrect calculations of unrealized losses and improper handling of loan defaults.

# Fix
Reset isImpaired to false when remove loan impairment

# Verification
- Key Invariant
   After reset to false，the correct `netInterest`, `netLateInterest` and `protocolFees` will be get in triggerDefault.
- Run tests
   test_RemoveLoanImpairment
   test_TriggerDefault_WhenLoanRemoveImpair

I add a new test case `test_TriggerDefault_WhenLoanRemoveImpair` to simulate remove an impaired loan. This case can check interests and remainingLosses are correct after the `isImpaired` flag set back to false.

After this fixing, the issue [Incorrect Accounting on Loan Removal](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#6512162162864dbba56f906767b448dc) also not happen anymore. 