### PR TITLE
fix: check seller only can withdraw after the loan funded

### DIFF
--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -298,6 +298,10 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
 
         uint256 drawableFunds_ = loan_.drawableFunds;
 
+        if (drawableFunds_ == 0) {
+            revert Errors.LoanManager_LoanNotFunded();
+        }
+
         loan_.drawableFunds = 0;
 
         IERC721(loan_.receivableAsset).safeTransferFrom(msg.sender, address(this), loan_.receivableTokenId);

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -125,6 +125,9 @@ library Errors {
     /// @notice Thrown when an asset address is set to 0 for a loan manager.
     error LoanManager_AssetZeroAddress();
 
+    /// @notice Thrown when the seller withraw fund before the loan be funded.
+    error LoanManager_LoanNotFunded();
+
     /*//////////////////////////////////////////////////////////////
                            WITHDRAWAL MANAGER
     //////////////////////////////////////////////////////////////*/

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -270,18 +270,20 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         tokenId_ = receivable.createReceivable(defaults.createReceivable());
     }
 
-    function createDefaultLoan() internal {
-        uint256 receivablesTokenId_ = createDefaultReceivable();
+    function requestDefaultLoan(uint256 tokenId_) internal returns (uint16 loanId_) {
         changePrank(users.buyer);
-
-        // request loan
-        uint16 loanId_ = loanManager.requestLoan(
+        loanId_ = loanManager.requestLoan(
             address(receivable),
-            receivablesTokenId_,
+            tokenId_,
             defaults.GRACE_PERIOD(),
             defaults.PRINCIPAL_REQUESTED(),
             [defaults.INTEREST_RATE(), defaults.LATE_INTEREST_PREMIUM_RATE()]
         );
+    }
+
+    function createDefaultLoan() internal {
+        uint256 receivablesTokenId_ = createDefaultReceivable();
+        uint16 loanId_ = requestDefaultLoan(receivablesTokenId_);
 
         changePrank(users.poolAdmin);
         loanManager.fundLoan(loanId_);

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -281,7 +281,7 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         );
     }
 
-    function createDefaultLoan() internal {
+    function fundDefaultLoan() internal {
         uint256 receivablesTokenId_ = createDefaultReceivable();
         uint16 loanId_ = requestDefaultLoan(receivablesTokenId_);
 

--- a/tests/integration/concrete/loan-manager/accrued-interest/accruedInterest.t.sol
+++ b/tests/integration/concrete/loan-manager/accrued-interest/accruedInterest.t.sol
@@ -20,7 +20,7 @@ contract AccruedInterest_LoanManager_Integration_Concrete_Test is
         assertEq(loanManager.accruedInterest(), 0);
     }
 
-    function test_AccruedInterest_AccountingNotUpdated() external whenLoanCreated {
+    function test_AccruedInterest_AccountingNotUpdated() external whenLoanFunded {
         // not matured
         vm.warp(MAY_1_2023 + 15 days);
         uint256 accruedInterest = defaults.NEW_RATE_ZERO_FEE_RATE() * 15 days / 1e27;
@@ -34,7 +34,7 @@ contract AccruedInterest_LoanManager_Integration_Concrete_Test is
         assertEq(loanManager.accruedInterest(), accruedInterest);
     }
 
-    function test_AccruedInterest() external whenLoanCreated whenAccountingUpdated {
+    function test_AccruedInterest() external whenLoanFunded whenAccountingUpdated {
         // not matured
         vm.warp(defaults.REPAYMENT_TIMESTAMP() - 1 days);
 

--- a/tests/integration/concrete/loan-manager/assets-under-management/assetsUnderManagement.t.sol
+++ b/tests/integration/concrete/loan-manager/assets-under-management/assetsUnderManagement.t.sol
@@ -20,17 +20,17 @@ contract AssetsUnderManagement_LoanManager_Integration_Concrete_Test is
         assertEq(loanManager.assetsUnderManagement(), 0);
     }
 
-    function test_AssetsUnderManagement_OneLoan_AtStartTime() external whenLoanCreated {
+    function test_AssetsUnderManagement_OneLoan_AtStartTime() external whenLoanFunded {
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED());
     }
 
-    function test_AssetsUnderManagement_OneLoan_InMiddle_NotUpdated() external whenLoanCreated {
+    function test_AssetsUnderManagement_OneLoan_InMiddle_NotUpdated() external whenLoanFunded {
         vm.warp(MAY_1_2023 + 10 days);
         uint256 accruedInterestEach = defaults.NEW_RATE_ZERO_FEE_RATE() * 10 days / 1e27;
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() + accruedInterestEach);
     }
 
-    function test_AssetsUnderManagement_OneLoan_InMiddle_Updated() external whenLoanCreated {
+    function test_AssetsUnderManagement_OneLoan_InMiddle_Updated() external whenLoanFunded {
         vm.warp(MAY_1_2023 + 10 days);
         uint256 accruedInterestEach = defaults.NEW_RATE_ZERO_FEE_RATE() * 10 days / 1e27;
 
@@ -53,13 +53,13 @@ contract AssetsUnderManagement_LoanManager_Integration_Concrete_Test is
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() + accountedInterest);
     }
 
-    function test_AssetsUnderManagement_OneLoan_Defaulted_NotUpdate() external whenLoanCreated {
+    function test_AssetsUnderManagement_OneLoan_Defaulted_NotUpdate() external whenLoanFunded {
         vm.warp(MAY_1_2023 + 100 days);
         uint256 accruedInterestEach = defaults.NEW_RATE_ZERO_FEE_RATE() * 100 days / 1e27;
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() + accruedInterestEach);
     }
 
-    function test_AssetsUnderManagement_OneLoan_Defaulted_Update() external whenLoanCreated {
+    function test_AssetsUnderManagement_OneLoan_Defaulted_Update() external whenLoanFunded {
         vm.warp(MAY_1_2023 + 100 days);
 
         changePrank(users.poolAdmin);
@@ -68,22 +68,22 @@ contract AssetsUnderManagement_LoanManager_Integration_Concrete_Test is
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() + accountedInterest);
     }
 
-    function test_AssetsUnderManagement_MultipleLoans_AtStartTime() external whenTwoLoansCreated {
+    function test_AssetsUnderManagement_MultipleLoans_AtStartTime() external whenTwoLoansFunded {
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() * 2);
     }
 
-    function test_AssetsUnderManagement_MultipleLoans_InMiddle_NotUpdate() external whenTwoLoansCreated {
+    function test_AssetsUnderManagement_MultipleLoans_InMiddle_NotUpdate() external whenTwoLoansFunded {
         vm.warp(MAY_1_2023 + 10 days);
         uint256 accruedInterest = (defaults.NEW_RATE_ZERO_FEE_RATE() * 10 days) * 2 / 1e27;
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() * 2 + accruedInterest);
     }
 
-    function test_AssetsUnderManagement_MultipleLoans_InMiddle_Update() external whenTwoLoansCreated {
+    function test_AssetsUnderManagement_MultipleLoans_InMiddle_Update() external whenTwoLoansFunded {
         vm.warp(MAY_1_2023 + 10 days);
         uint256 accruedInterest = (defaults.NEW_RATE_ZERO_FEE_RATE() * 10 days) * 2 / 1e27;
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() * 2 + accruedInterest);
 
-        createDefaultLoan();
+        fundDefaultLoan();
         vm.warp(MAY_1_2023 + 15 days);
         accruedInterest = (defaults.NEW_RATE_ZERO_FEE_RATE() * 10 days) * 2 / 1e27;
         // since fund another loan will trigger _advanceGlobalPaymentAccounting()
@@ -97,13 +97,13 @@ contract AssetsUnderManagement_LoanManager_Integration_Concrete_Test is
         );
     }
 
-    function test_AssetsUnderManagement_MultipleLoans_Defaulted_NotUpdate() external whenTwoLoansCreated {
+    function test_AssetsUnderManagement_MultipleLoans_Defaulted_NotUpdate() external whenTwoLoansFunded {
         vm.warp(MAY_1_2023 + 100 days);
         uint256 accruedInterest = (defaults.NEW_RATE_ZERO_FEE_RATE() * 100 days) * 2 / 1e27;
         assertEq(loanManager.assetsUnderManagement(), defaults.PRINCIPAL_REQUESTED() * 2 + accruedInterest);
     }
 
-    function test_AssetsUnderManagement_MultipleLoans_Defaulted_Update() external whenTwoLoansCreated {
+    function test_AssetsUnderManagement_MultipleLoans_Defaulted_Update() external whenTwoLoansFunded {
         vm.warp(MAY_1_2023 + 100 days);
 
         changePrank(users.poolAdmin);

--- a/tests/integration/concrete/loan-manager/get-loan-info/getLoanInfo.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-info/getLoanInfo.t.sol
@@ -20,7 +20,7 @@ contract GetLoanInfo_LoanManager_Integration_Concrete_Test is
     {
         LoanManager_Integration_Concrete_Test.setUp();
 
-        createDefaultLoan();
+        fundDefaultLoan();
 
         LOAN_INFO = Loan.Info({
             buyer: users.buyer,

--- a/tests/integration/concrete/loan-manager/get-loan-payment-breakdown/getLoanPaymentBreakdown.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-payment-breakdown/getLoanPaymentBreakdown.t.sol
@@ -23,7 +23,7 @@ contract GetLoanPaymentBreakdown_LoanManager_Integration_Concrete_Test is
     }
 
     function test_GetLoanPaymentBreakdown_ExistLoanId_NotDefaulted() external {
-        createDefaultLoan();
+        fundDefaultLoan();
         vm.warp(MAY_1_2023 + 10 days);
         (uint256 principal_, uint256 interest_) = loanManager.getLoanPaymentBreakdown(1);
         assertEq(principal_, defaults.PRINCIPAL_REQUESTED());
@@ -31,7 +31,7 @@ contract GetLoanPaymentBreakdown_LoanManager_Integration_Concrete_Test is
     }
 
     function test_GetLoanPaymentBreakdown_ExistLoanId_Defaulted() external {
-        createDefaultLoan();
+        fundDefaultLoan();
         // 9 days + 1s -> 10 full days late
         vm.warp(defaults.MAY_31_2023() + 9 days + 1);
 

--- a/tests/integration/concrete/loan-manager/get-loan-payment-detailed-breakdown/getLoanPaymentDetailedBreakdown.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-payment-detailed-breakdown/getLoanPaymentDetailedBreakdown.t.sol
@@ -24,7 +24,7 @@ contract GetLoanPaymentDetailedBreakdown_LoanManager_Integration_Concrete_Test i
     }
 
     function test_GetLoanPaymentDetailedBreakdown_ExistLoanId_NotDefaulted() external {
-        createDefaultLoan();
+        fundDefaultLoan();
         vm.warp(MAY_1_2023 + 10 days);
         (uint256 principal_, uint256[2] memory interest_) = loanManager.getLoanPaymentDetailedBreakdown(1);
         assertEq(principal_, defaults.PRINCIPAL_REQUESTED());
@@ -33,7 +33,7 @@ contract GetLoanPaymentDetailedBreakdown_LoanManager_Integration_Concrete_Test i
     }
 
     function test_GetLoanPaymentDetailedBreakdown_ExistLoanId_Defaulted() external {
-        createDefaultLoan();
+        fundDefaultLoan();
         // 9 days + 1s -> 10 full days late
         vm.warp(defaults.MAY_31_2023() + 9 days + 1);
 

--- a/tests/integration/concrete/loan-manager/impair-loan/impairLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/impair-loan/impairLoan.t.sol
@@ -14,7 +14,7 @@ contract ImpairLoan_LoanManager_Integration_Concrete_Test is
         LoanManager_Integration_Concrete_Test.setUp();
         Callable_Integration_Shared_Test.setUp();
 
-        createDefaultLoan();
+        fundDefaultLoan();
     }
 
     modifier whenLoanIsNotImpaired() {

--- a/tests/integration/concrete/loan-manager/remove-loan-impairment/removeLoanImpairment.t.sol
+++ b/tests/integration/concrete/loan-manager/remove-loan-impairment/removeLoanImpairment.t.sol
@@ -14,7 +14,7 @@ contract RemoveLoanImpairment_LoanManager_Integration_Concrete_Test is
         LoanManager_Integration_Concrete_Test.setUp();
         Callable_Integration_Shared_Test.setUp();
 
-        createDefaultLoan();
+        fundDefaultLoan();
     }
 
     modifier whenPaymentIdIsNotZero() {

--- a/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
@@ -50,7 +50,7 @@ contract RepayLoan_LoanManager_Integration_Concrete_Test is
     }
 
     function test_RepayLoan_WhenLoanImpaired() external whenNotPaused whenHasLoanRequested {
-        createDefaultLoan();
+        fundDefaultLoan();
 
         changePrank(users.poolAdmin);
         loanManager.impairLoan(1);
@@ -65,7 +65,7 @@ contract RepayLoan_LoanManager_Integration_Concrete_Test is
     function test_RepayLoan_WhenAfterDueDate() external whenNotPaused whenHasLoanRequested whenLoanNotImpaired {
         uint256 dueDate_ = defaults.REPAYMENT_TIMESTAMP();
 
-        createDefaultLoan();
+        fundDefaultLoan();
 
         vm.warp(dueDate_ + 1);
 
@@ -87,7 +87,7 @@ contract RepayLoan_LoanManager_Integration_Concrete_Test is
 
         uint256 poolBalanceBefore = usdc.balanceOf(address(pool));
 
-        createDefaultLoan();
+        fundDefaultLoan();
 
         vm.warp(defaults.MAY_31_2023());
 
@@ -137,7 +137,7 @@ contract RepayLoan_LoanManager_Integration_Concrete_Test is
 
         uint256 poolBalanceBefore = usdc.balanceOf(address(pool));
 
-        createDefaultLoan();
+        fundDefaultLoan();
         IERC721 receivable = IERC721(address(receivable));
 
         changePrank(users.seller);

--- a/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
+++ b/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
@@ -14,7 +14,7 @@ contract TriggerDefault_LoanManager_Integration_Concrete_Test is
         LoanManager_Integration_Concrete_Test.setUp();
         Callable_Integration_Shared_Test.setUp();
 
-        createDefaultLoan();
+        fundDefaultLoan();
     }
 
     modifier whenBlockTimestampGreaterThanDueDatePlusGracePeriod() {

--- a/tests/integration/concrete/loan-manager/update-accounting/updateAccounting.t.sol
+++ b/tests/integration/concrete/loan-manager/update-accounting/updateAccounting.t.sol
@@ -25,7 +25,7 @@ contract UpdateAccounting_LoanManager_Integration_Concrete_Test is
     function test_UpdateAccounting() external whenNotPaused {
         assertEq(loanManager.accruedInterest(), 0);
 
-        createDefaultLoan();
+        fundDefaultLoan();
         vm.warp(defaults.MAY_31_2023() + 70 days);
 
         assertEq(loanManager.accruedInterest(), defaults.NEW_RATE_ZERO_FEE_RATE() * 100 days / 1e27);

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
@@ -27,7 +27,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         loanManager.withdrawFunds(1, address(0));
     }
 
-    function test_RevertWhen_CallerNotLoanSeller() external whenDefaultLoanCreated whenNotPaused {
+    function test_RevertWhen_CallerNotLoanSeller() external whenDefaultLoanFunded whenNotPaused {
         changePrank(users.eve);
         vm.expectRevert(abi.encodeWithSelector(Errors.LoanManager_CallerNotSeller.selector, users.seller));
         loanManager.withdrawFunds(1, address(0));
@@ -38,7 +38,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         loanManager.withdrawFunds(1, address(0));
     }
 
-    function test_WithdrawFunds_WhenLoanNotRepaid() external whenDefaultLoanCreated whenNotPaused whenCallerSeller {
+    function test_WithdrawFunds_WhenLoanNotRepaid() external whenDefaultLoanFunded whenNotPaused whenCallerSeller {
         uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
         uint256 loanManagerBalanceBefore = usdc.balanceOf(address(loanManager));
 
@@ -55,7 +55,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         assertEq(loanManagerBalanceAfter, loanManagerBalanceBefore - principalRequested);
     }
 
-    function test_WithdrawFunds() external whenDefaultLoanCreated whenNotPaused whenCallerSeller whenLoanRepaid {
+    function test_WithdrawFunds() external whenDefaultLoanFunded whenNotPaused whenCallerSeller whenLoanRepaid {
         changePrank(users.buyer);
         loanManager.repayLoan(1);
 
@@ -90,8 +90,8 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         _;
     }
 
-    modifier whenDefaultLoanCreated() {
-        createDefaultLoan();
+    modifier whenDefaultLoanFunded() {
+        fundDefaultLoan();
         _;
     }
 

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
@@ -5,13 +5,16 @@ withdrawFunds.t.sol
    ├── when the caller is not the seller
    │  └── it should revert
    └── when the caller is the seller
-      ├── when the buyer is not repay the loan
-      │  ├── it should transfer the collateral receivable from the seller to the loanManager
-      │  ├── it should transfer the drawable amount from loanManager to the seller
-      │  └── it should emit a {FundsWithdrawn} event
-      └── when the buyer is repay the loan
-         ├── it should transfer the collateral receivable from the seller to the loanManager
-         ├── it should burn the receivable token
-         ├── it should emit a {AssetBurned} event
-         ├── it should transfer the drawable amount from loanManager to the seller
-         └── it should emit a {FundsWithdrawn} event
+      ├── when the loan not be funded
+      │  └── it should revert
+      └── when the loan been funded
+         ├── when the buyer is not repay the loan
+         │  ├── it should transfer the collateral receivable from the seller to the loanManager
+         │  ├── it should transfer the drawable amount from loanManager to the seller
+         │  └── it should emit a {FundsWithdrawn} event
+         └── when the buyer is repay the loan
+            ├── it should transfer the collateral receivable from the seller to the loanManager
+            ├── it should burn the receivable token
+            ├── it should emit a {AssetBurned} event
+            ├── it should transfer the drawable amount from loanManager to the seller
+            └── it should emit a {FundsWithdrawn} event

--- a/tests/integration/concrete/pool-configurator/request-funds/requestFunds.t.sol
+++ b/tests/integration/concrete/pool-configurator/request-funds/requestFunds.t.sol
@@ -117,7 +117,7 @@ contract RequestFunds_Integration_Concrete_Test is PoolConfigurator_Integration_
         _defaultWithdraw(withdrawAmount_);
 
         // create loan
-        createDefaultLoan();
+        fundDefaultLoan();
 
         // seller withdraw fund
         changePrank(users.seller);

--- a/tests/integration/concrete/pool-configurator/trigger-default/triggerDefault.t.sol
+++ b/tests/integration/concrete/pool-configurator/trigger-default/triggerDefault.t.sol
@@ -10,7 +10,7 @@ contract TriggerDefault_Integration_Concrete_Test is PoolConfigurator_Integratio
         PoolConfigurator_Integration_Shared_Test.setUp();
 
         poolConfigurator.depositCover(defaults.COVER_AMOUNT());
-        createDefaultLoan();
+        fundDefaultLoan();
     }
 
     function test_RevertWhen_PoolConfiguratorPaused_ProtocolPaused() external {

--- a/tests/integration/concrete/pool/convert-to/convertTo.t.sol
+++ b/tests/integration/concrete/pool/convert-to/convertTo.t.sol
@@ -28,7 +28,7 @@ contract ConvertTo_Pool_Integration_Concrete_Test is Pool_Integration_Shared_Tes
 
     function _createUnrealizedLosses() internal {
         // Unrealized losses is FACE_AMOUNT
-        createDefaultLoan();
+        fundDefaultLoan();
         loanManager.impairLoan(1);
     }
 }

--- a/tests/integration/concrete/pool/total-assets/totalAssets.t.sol
+++ b/tests/integration/concrete/pool/total-assets/totalAssets.t.sol
@@ -5,8 +5,6 @@ import { Pool } from "contracts/Pool.sol";
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 
-import { console2 } from "@forge-std/console2.sol";
-
 contract TotalAssets_Pool_Integration_Concrete_Test is Pool_Integration_Shared_Test {
     function setUp() public virtual override(Pool_Integration_Shared_Test) {
         Pool_Integration_Shared_Test.setUp();
@@ -17,7 +15,7 @@ contract TotalAssets_Pool_Integration_Concrete_Test is Pool_Integration_Shared_T
         assertEq(pool.totalAssets(), defaults.POOL_ASSETS(), "total assets");
 
         // after loan created
-        createDefaultLoan();
+        fundDefaultLoan();
         assertEq(
             pool.totalAssets(), usdc.balanceOf(address(pool)) + loanManager.assetsUnderManagement(), "total assets"
         );

--- a/tests/integration/concrete/withdrawal-manager/process-exit/processExit.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/process-exit/processExit.t.sol
@@ -130,8 +130,8 @@ contract ProcessExit_Integration_Concrete_Test is WithdrawalManager_Integration_
         changePrank(users.poolAdmin);
         poolConfigurator.depositCover(defaults.COVER_AMOUNT());
 
-        // create loan
-        createDefaultLoan();
+        // create and fund loan
+        fundDefaultLoan();
 
         // seller withdraw fund
         changePrank(users.seller);

--- a/tests/integration/shared/loan-manager/LoanManager.t.sol
+++ b/tests/integration/shared/loan-manager/LoanManager.t.sol
@@ -19,14 +19,14 @@ abstract contract LoanManager_Integration_Shared_Test is Base_Test {
         loanManager.fundLoan(loanId_);
     }
 
-    modifier whenLoanCreated() {
-        createDefaultLoan();
+    modifier whenLoanFunded() {
+        fundDefaultLoan();
         _;
     }
 
-    modifier whenTwoLoansCreated() {
-        createDefaultLoan();
-        createDefaultLoan();
+    modifier whenTwoLoansFunded() {
+        fundDefaultLoan();
+        fundDefaultLoan();
         _;
     }
 


### PR DESCRIPTION
# Summary
Lack of Validation for Loan Funding Status

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=97#921949e3b5534f28b05d45b0ca3f3039

# Description
The withdrawFunds function does not validate whether the loan has been fully funded before allowing the seller to withdraw funds. The situation could result in the Seller withdrawing 0 amount but having already transferred the Receivable to LoanManager.

# Fix
Check the drawable funds is not 0 (be funded) before seller can withdraw.

# Verification
- Run tests
   `test_RevertWhen_LoanNotFunded`