### PR TITLE
fix: maxWithdraw return 0 instead of revert

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -221,8 +221,7 @@ contract Pool is IPool, ERC20Permit {
     /// @inheritdoc IERC4626
     function maxWithdraw(address owner_) public pure override returns (uint256 maxAssets_) {
         owner_;
-        maxAssets_; // Not implemented
-        revert Errors.Pool_WithdrawalNotImplemented();
+        maxAssets_ = 0;
     }
 
     /// @inheritdoc IERC4626

--- a/tests/integration/concrete/pool/max-withdraw/maxWithdraw.t.sol
+++ b/tests/integration/concrete/pool/max-withdraw/maxWithdraw.t.sol
@@ -11,7 +11,7 @@ contract MaxWithdraw_Pool_Integration_Concrete_Test is Pool_Integration_Shared_T
     }
 
     function test_MaxWithdraw() external {
-        vm.expectRevert(Errors.Pool_WithdrawalNotImplemented.selector);
-        pool.maxWithdraw({ owner: users.receiver });
+        uint256 maxAssets_ = pool.maxWithdraw({ owner: users.receiver });
+        assertEq(maxAssets_, 0);
     }
 }


### PR DESCRIPTION
# Summary
maxWithdraw() of ERC4626 Vaults must not revert

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#05f040e7d5414e689cd200ce60c762de

# Description
According to EIP-4626, `maxWithdraw()` must not revert. But the function `maxWithdraw()` reverts in the when called in the Pool contract which uses the ERC-4626 standard.
According to the EIP, if withdrawals are entirely disabled (even temporarily) it MUST return 0.

https://eips.ethereum.org/EIPS/eip-4626#maxwithdraw

# Fix
Fix `maxWithdraw` by return 0 instead of revert.

# Verification
- Run tests
   `test_MaxWithdraw`