### PR TITLE
fix: fix redundant check for depositWithPermit

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -63,7 +63,8 @@ contract Pool is IPool, ERC20Permit {
 
         _asset.permit(_msgSender(), address(this), assets_, deadline_, v_, r_, s_);
 
-        shares_ = deposit(assets_, receiver_);
+        shares_ = previewDeposit(assets_);
+        _deposit(_msgSender(), receiver_, assets_, shares_);
     }
 
     /// @inheritdoc IPool


### PR DESCRIPTION
# Summary
Optimization: Redundant Checks in depositWithPermit Function

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#67574839c68649a38ff85322ce818154

# Description
The current implementation of the `depositWithPermit` function uses the `deposit` function, which performs redundant checks that depositWithPermit has already handled. In this implementation, we check zero address of receiver and maxDeposit twice.

# Fix
Refactor `depositWithPermit` to remove redundant check.

# Verification
- Run tests
   `DepositWithPermit_Pool_Integration_Concrete_Test`
   `MintWithPermit_Pool_Integration_Concrete_Test`