### PR TITLE
fix: Remove the restriction that only the seller can withdraw funds

### DIFF
--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -291,11 +291,6 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
     function withdrawFunds(uint16 loanId_, address destination_) external override whenNotPaused {
         Loan.Info storage loan_ = _loans[loanId_];
 
-        // Only the seller can drawdown funds
-        if (msg.sender != loan_.seller) {
-            revert Errors.LoanManager_CallerNotSeller({ expectedSeller_: loan_.seller });
-        }
-
         uint256 drawableFunds_ = loan_.drawableFunds;
 
         loan_.drawableFunds = 0;

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -88,9 +88,6 @@ library Errors {
                               LOAN MANAGER
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when `msg.sender` is not the seller.
-    error LoanManager_CallerNotSeller(address expectedSeller_);
-
     /// @notice Thrown when buyer approves an invalid receivable (either buyer or seller is not whitelisted or repayment
     /// timestamp is in the past).
     error LoanManager_InvalidReceivable(uint256 receivablesTokenId_);

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
@@ -29,16 +29,11 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         loanManager.withdrawFunds(1, address(0));
     }
 
-    function test_RevertWhen_CallerNotLoanSeller() external whenNotPaused {
-        changePrank(users.eve);
-        vm.expectRevert(abi.encodeWithSelector(Errors.LoanManager_CallerNotSeller.selector, users.seller));
-        loanManager.withdrawFunds(1, address(0));
-    }
-
-    function test_WithdrawFunds_WhenLoanNotRepaid() external whenNotPaused whenCallerSeller {
+    function test_WithdrawFunds_WhenLoanNotRepaid() external whenNotPaused {
         uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
         uint256 loanManagerBalanceBefore = usdc.balanceOf(address(loanManager));
 
+        changePrank(users.seller);
         IERC721(address(receivable)).approve(address(loanManager), defaults.RECEIVABLE_TOKEN_ID());
 
         vm.expectEmit(true, true, true, true);
@@ -52,10 +47,7 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         assertEq(loanManagerBalanceAfter, loanManagerBalanceBefore - principalRequested);
     }
 
-    function test_WithdrawFunds() external whenNotPaused whenCallerSeller whenLoanRepaid {
-        changePrank(users.buyer);
-        loanManager.repayLoan(1);
-
+    function test_WithdrawFunds() external whenNotPaused whenLoanRepaid {
         changePrank(users.seller);
         uint256 principalRequested = defaults.PRINCIPAL_REQUESTED();
         uint256 loanManagerBalanceBefore = usdc.balanceOf(address(loanManager));
@@ -81,12 +73,9 @@ contract WithdrawFunds_LoanManager_Integration_Concrete_Test is
         IERC721(address(receivable)).ownerOf(receivableTokenId);
     }
 
-    modifier whenCallerSeller() {
-        changePrank(users.seller);
-        _;
-    }
-
     modifier whenLoanRepaid() {
+        changePrank(users.buyer);
+        loanManager.repayLoan(1);
         _;
     }
 }

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.tree
@@ -2,16 +2,13 @@ withdrawFunds.t.sol
 ├── when the function is paused
 │  └── it should revert
 └── when the function is not paused
-   ├── when the caller is not the seller
-   │  └── it should revert
-   └── when the caller is the seller
-      ├── when the buyer is not repay the loan
-      │  ├── it should transfer the collateral receivable from the seller to the loanManager
-      │  ├── it should transfer the drawable amount from loanManager to the seller
-      │  └── it should emit a {FundsWithdrawn} event
-      └── when the buyer is repay the loan
-         ├── it should transfer the collateral receivable from the seller to the loanManager
-         ├── it should burn the receivable token
-         ├── it should emit a {AssetBurned} event
-         ├── it should transfer the drawable amount from loanManager to the seller
-         └── it should emit a {FundsWithdrawn} event
+   ├── when the buyer is not repay the loan
+   │  ├── it should transfer the collateral receivable from the seller to the loanManager
+   │  ├── it should transfer the drawable amount from loanManager to the seller
+   │  └── it should emit a {FundsWithdrawn} event
+   └── when the buyer is repay the loan
+      ├── it should transfer the collateral receivable from the seller to the loanManager
+      ├── it should burn the receivable token
+      ├── it should emit a {AssetBurned} event
+      ├── it should transfer the drawable amount from loanManager to the seller
+      └── it should emit a {FundsWithdrawn} event


### PR DESCRIPTION
# Summary
NFT Holder Cannot Withdraw Repaid Amount Due to Loan Seller Check

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#9c502481f45d4672b950f78323f2c5b7

# Description
The Receivable NFT, which represents a transferable debt claim, restricts the ability to withdraw the repayment of the debt to the original seller while allowing the transfer of the NFT. In the LoanManager.sol contract, the withdrawFunds() function checks if the caller is the original seller, preventing new NFT holders from accessing repaid funds. This disallows the transfer of the debt along with its claim, leading to potential disputes and misrepresentations in transactions involving the NFT.

# Fix
Remove the restriction that only the seller can withdraw funds

# Verification
- Run tests
   `WithdrawFunds_LoanManager_Integration_Concrete_Test`