### PR TITLE
fix: processExit shares check

### DIFF
--- a/contracts/WithdrawalManager.sol
+++ b/contracts/WithdrawalManager.sol
@@ -249,11 +249,9 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
             revert Errors.WithdrawalManager_NoRequest(owner_);
         }
 
-        if (requestedShares_ != lockedShares_) {
+        if (requestedShares_ > lockedShares_) {
             revert Errors.WithdrawalManager_InvalidShares(owner_, requestedShares_, lockedShares_);
         }
-
-        bool partialLiquidity_;
 
         (uint64 windowStart_, uint64 windowEnd_) = getWindowAtId(exitCycleId_);
 
@@ -261,7 +259,7 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
             revert Errors.WithdrawalManager_NotInWindow(block.timestamp, windowStart_, windowEnd_);
         }
 
-        (redeemableShares_, resultingAssets_, partialLiquidity_) = getRedeemableAmounts(lockedShares_, owner_);
+        (redeemableShares_, resultingAssets_) = getRedeemableAmounts(lockedShares_, owner_);
 
         // Transfer redeemable shares back to the owner in order to be burned in the pool, re-lock remaining shares
         IERC20(_pool()).transfer(owner_, redeemableShares_);
@@ -273,7 +271,7 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
         // If there are any remaining shares, move them to the next cycle
         // In case of partial liquidity, move shares only one cycle forward (instead of two)
         if (lockedShares_ != 0) {
-            exitCycleId_ = getCurrentCycleId() + (partialLiquidity_ ? 1 : 2);
+            exitCycleId_ = getCurrentCycleId() + 1;
             totalCycleShares[exitCycleId_] += lockedShares_;
         } else {
             exitCycleId_ = 0; // User without exit cycle id has no withdrawal request
@@ -342,7 +340,7 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
             return (redeemableShares_, resultingAssets_);
         }
 
-        (redeemableShares_, resultingAssets_,) = getRedeemableAmounts(lockedShares_, owner_);
+        (redeemableShares_, resultingAssets_) = getRedeemableAmounts(lockedShares_, owner_);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -410,7 +408,7 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
         public
         view
         override
-        returns (uint256 redeemableShares_, uint256 resultingAssets_, bool partialLiquidity_)
+        returns (uint256 redeemableShares_, uint256 resultingAssets_)
     {
         IPoolConfigurator poolConfigurator_ = IPoolConfigurator(_poolConfigurator());
 
@@ -419,7 +417,7 @@ contract WithdrawalManager is WithdrawalManagerStorage, IWithdrawalManager, Vers
         uint256 totalSupply_ = IPool(_pool()).totalSupply();
         uint256 totalRequestedLiquidity_ = totalCycleShares[exitCycleId[owner_]] * totalAssetsWithLosses_ / totalSupply_;
 
-        partialLiquidity_ = availableLiquidity_ < totalRequestedLiquidity_;
+        bool partialLiquidity_ = availableLiquidity_ < totalRequestedLiquidity_;
 
         // Calculate maximum redeemable shares while maintaining a pro-rata distribution
         redeemableShares_ =

--- a/contracts/interfaces/IWithdrawalManager.sol
+++ b/contracts/interfaces/IWithdrawalManager.sol
@@ -155,12 +155,11 @@ interface IWithdrawalManager is IWithdrawalManagerStorage {
     /// @param owner_ The address of the owner.
     /// @return redeemableShares_ The amount of redeemable shares.
     /// @return resultingAssets_ The corresponding amount of assets with the redeemable shares.
-    /// @return partialLiquidity_ True if there is only partial liquidity.
     function getRedeemableAmounts(
         uint256 lockedShares_,
         address owner_
     )
         external
         view
-        returns (uint256 redeemableShares_, uint256 resultingAssets_, bool partialLiquidity_);
+        returns (uint256 redeemableShares_, uint256 resultingAssets_);
 }

--- a/tests/integration/concrete/withdrawal-manager/get-redeemable-amounts/getRedeemableAmounts.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-redeemable-amounts/getRedeemableAmounts.t.sol
@@ -16,11 +16,10 @@ contract GetRedeemableAmounts_Integration_Concrete_Test is WithdrawalManager_Int
 
         addDefaultShares();
 
-        (uint256 redeemableShares_, uint256 resultingAssets_, bool partialLiquidity_) =
+        (uint256 redeemableShares_, uint256 resultingAssets_) =
             withdrawalManager.getRedeemableAmounts({ lockedShares_: addShares_, owner_: users.receiver });
 
         assertEq(redeemableShares_, addShares_);
         assertEq(resultingAssets_, addShares_ * defaults.POOL_ASSETS() / defaults.POOL_SHARES());
-        assertFalse(partialLiquidity_);
     }
 }

--- a/tests/integration/concrete/withdrawal-manager/process-exit/processExit.tree
+++ b/tests/integration/concrete/withdrawal-manager/process-exit/processExit.tree
@@ -5,9 +5,9 @@ processExit.t.sol
    ├── when the locked shares of the owner is 0
    │  └── it should revert
    └── when the locked shares of the owner is not 0
-      ├── when the owner's requested shares is not equal to the locked shares
+      ├── when the owner's requested shares is greater then locked shares
       │  └── it should revert
-      └── when the owner's requested shares is equal to the locked shares
+      └── when the owner's requested shares not greater then locked shares
          ├── when the current timestamp is not in the window
          │  └── it should revert
          └── when the current timestamp is in the window


### PR DESCRIPTION
# Summary
The redeem() function reverts on valid values of shares

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#831e329f73b0407aae3bb85d68d9ec48

# Description
`Pool::redeem` does not allow any value of shares as a parameter to be passed other than a value equal to **lockedShares.** This is because, `Pool::redeem` calls ` PoolConfigurator::processRedeem`, which itself calls `WithdrawalManager::processExit`.

Now in this `processExit()` function, there is an if statement on line:252 which uses strict equality (or inequality here) which results in a revert if **requestedShares_** is not equal to the **lockedShares**.

But this strict inequality results in the `Pool::redeem(uint256 shares)` to fail for any value of shares other than **lockedShares_**.

Ideally this is not expected as the function should work for any valid value of shares which can be set to any value as a parameter **shares_** of the redeem() function.

# Fix
1. In `WithdrawalManager::processExit`, change the condition for shares from `!=` to `>` that align to the check in `Pool::redeem`.
2. Remove `partialLiquidity_` returns from getRedeemableAmounts. Cuz we use **lockedShares** to getRedeemableAmounts, this means we only allow users to redeem all of amount that they requested, so if `lockedShares_ - redeemableShares_ != 0` it must be pro-rata distributions(means partialLiquidity will always be **true**), that's why we remove the partialLiquidity bool.

# Verification
- Run tests
   `ProcessExit_Integration_Concrete_Test`
   `GetRedeemableAmounts_Integration_Concrete_Test`