### PR TITLE
Fix: add storage gap for future changes

### DIFF
--- a/contracts/abstracts/Governable.sol
+++ b/contracts/abstracts/Governable.sol
@@ -38,4 +38,7 @@ abstract contract Governable is IGovernable {
         // Log the transfer of the governor.
         emit IGovernable.TransferGovernor({ oldGovernor: msg.sender, newGovernor: newGovernor });
     }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
 }


### PR DESCRIPTION
# Summary

`Governable` contract is an upgradeable contract, but it does not contain the storage gaps, this might lead to storage collision if future upgrade wants to add new state variable in the contract.

# Description

Details can be found in the audit finding [description](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#7e04bc3b46e24717ac7847b608781f27).

# Modifiction

In this PR, I added a storage gap, which is a `uint256` array of length 50, as you can see in the modifications to the `Governable` contract.

# Verification

Run the following test case, ensuring the modification will not affect the contract upgrade logic.

`TransferGovernor_Governable_Unit_Concrete_Test`