### PR TITLE
fix: add zero address check when governor transfer

### DIFF
--- a/contracts/abstracts/Governable.sol
+++ b/contracts/abstracts/Governable.sol
@@ -32,6 +32,9 @@ abstract contract Governable is IGovernable {
 
     /// @inheritdoc IGovernable
     function transferGovernor(address newGovernor) external virtual override onlyGovernor {
+        if (newGovernor == address(0)) {
+            revert Errors.GovernorZeroAddress();
+        }
         // Effects: update the governor.
         governor = newGovernor;
 

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -33,6 +33,9 @@ library Errors {
     /// @notice Thrown when the new governor is zero address.
     error GovernorZeroAddress();
 
+    /// @notice Thrown when the address is zero address.
+    error ZeroAddress();
+
     /*//////////////////////////////////////////////////////////////
                            POOL CONFIGURATOR
     //////////////////////////////////////////////////////////////*/

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -30,8 +30,8 @@ library Errors {
     /// @notice Thrown when pool addresses provider is set to 0.
     error AddressesProviderZeroAddress();
 
-    /// @notice Thrown when the address is zero address.
-    error ZeroAddress();
+    /// @notice Thrown when the new governor is zero address.
+    error GovernorZeroAddress();
 
     /*//////////////////////////////////////////////////////////////
                            POOL CONFIGURATOR

--- a/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.t.sol
+++ b/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.t.sol
@@ -16,11 +16,20 @@ contract TransferGovernor_Governable_Unit_Concrete_Test is Governable_Test {
         mockGovernable.transferGovernor(users.eve);
     }
 
-    function test_TransferGovernor() external whenCallerGovernor {
+    function test_RevertWhen_NewGovernorIsZeroAddress() external whenCallerGovernor {
+        vm.expectRevert(Errors.GovernorZeroAddress.selector);
+        mockGovernable.transferGovernor(address(0));
+    }
+
+    function test_TransferGovernor() external whenGovernorNotZeroAddress whenCallerGovernor {
         vm.expectEmit(true, true, false, false);
         emit TransferGovernor(users.governor, users.eve);
 
         mockGovernable.transferGovernor(users.eve);
         assertEq(mockGovernable.governor(), users.eve);
+    }
+
+    modifier whenGovernorNotZeroAddress() {
+        _;
     }
 }

--- a/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.tree
+++ b/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.tree
@@ -2,6 +2,9 @@ transferGovernor.t.sol
 ├── when the caller is not governor
 │  └── it should revert
 └── when the caller is governor
-   ├── it should transfer to newGovernor
-   └── it should emit a {TransferGovernor} event
+   ├── when the new governor is zero address
+   │  └── it should revert
+   └── when the new governor is not zero address
+      ├── it should transfer to newGovernor
+      └── it should emit a {TransferGovernor} event
       

--- a/tests/unit/concrete/pool-addresses-provider/constructor/constructor.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/constructor/constructor.t.sol
@@ -20,11 +20,8 @@ contract Constructor_PoolAddressesProvider_Unit_Concrete_Test is PoolAddressesPr
     function test_RevertWhen_GovernorIsZeroAddress() external {
         string memory marketId_ = defaults.MARKET_ID();
 
+        vm.expectRevert(abi.encodeWithSelector(Errors.GovernorZeroAddress.selector));
         isleGlobals.transferGovernor(address(0));
-
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.PoolAddressesProvider_InvalidGlobals.selector, address(isleGlobals))
-        );
         new PoolAddressesProvider(marketId_, isleGlobals);
     }
 


### PR DESCRIPTION
# Summary

There is no zero address check in `Governable::transferGovernor`, an upgrade might accidentally configure the new governor to `address(0)` and lose the control to the proxy contract.

# Description

Detailed description can be found here in the audit [draft](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#fa51bd8bc7e743e09743a61162ea7226).

# Modification

I added a new error to indicate when the governor is transferred to the zero address. Additionally, I updated the tree file accordingly.

# Verification

Run `TransferGovernor_Governable_Unit_Concrete_Test`