### PR TITLE
fix: make proxy and implementation creating in same tx to prevent front run

### DIFF
--- a/contracts/interfaces/IPoolAddressesProvider.sol
+++ b/contracts/interfaces/IPoolAddressesProvider.sol
@@ -89,27 +89,24 @@ interface IPoolAddressesProvider {
     function getPoolConfigurator() external view returns (address);
 
     /// @notice Sets or initializes the PoolConfigurator proxy with a new implementation.
-    /// @param newPoolConfiguratorImpl The address of the new PoolConfigurator implementation.
     /// @param params The initialization parameters for the PoolConfigurator.
-    function setPoolConfiguratorImpl(address newPoolConfiguratorImpl, bytes calldata params) external;
+    function setPoolConfiguratorImpl(bytes calldata params) external;
 
     /// @notice Retrieves the address of the LoanManager proxy.
     /// @return The address of the LoanManager proxy.
     function getLoanManager() external view returns (address);
 
     /// @notice Sets or initializes the LoanManager proxy with a new implementation.
-    /// @param newLoanManagerImpl The address of the new LoanManager implementation.
     /// @param params The initialization parameters for the LoanManager.
-    function setLoanManagerImpl(address newLoanManagerImpl, bytes calldata params) external;
+    function setLoanManagerImpl(bytes calldata params) external;
 
     /// @notice Retrieves the address of the WithdrawalManager proxy.
     /// @return The address of the WithdrawalManager proxy.
     function getWithdrawalManager() external view returns (address);
 
     /// @notice Sets or initializes the WithdrawalManager proxy with a new implementation.
-    /// @param newWithdrawalManagerImpl The address of the new WithdrawalManager implementation.
     /// @param params The initialization parameters for the WithdrawalManager.
-    function setWithdrawalManagerImpl(address newWithdrawalManagerImpl, bytes calldata params) external;
+    function setWithdrawalManagerImpl(bytes calldata params) external;
 
     /// @notice Retrieves the address of IsleGlobals.
     /// @return The address of IsleGlobals.

--- a/scripts/DeployPool.s.sol
+++ b/scripts/DeployPool.s.sol
@@ -60,8 +60,6 @@ contract DeployPool is BaseScript {
         broadcast(governor)
         returns (address poolConfigurator_)
     {
-        address poolConfiguratorImpl_ = address(new PoolConfigurator(poolAddressesProvider_));
-
         bytes memory params_ = abi.encodeWithSelector(
             PoolConfigurator.initialize.selector,
             address(poolAddressesProvider_),
@@ -70,7 +68,7 @@ contract DeployPool is BaseScript {
             "ChargeSmith Pool",
             "CHG"
         );
-        poolAddressesProvider_.setPoolConfiguratorImpl(address(poolConfiguratorImpl_), params_);
+        poolAddressesProvider_.setPoolConfiguratorImpl(params_);
         poolConfigurator_ = poolAddressesProvider_.getPoolConfigurator();
     }
 
@@ -82,11 +80,8 @@ contract DeployPool is BaseScript {
         broadcast(governor)
         returns (address loanManager_)
     {
-        address loanManagerImpl_ = address(new LoanManager(poolAddressesProvider_));
-
         bytes memory params_ = abi.encodeWithSelector(LoanManager.initialize.selector, asset_);
-
-        poolAddressesProvider_.setLoanManagerImpl(address(loanManagerImpl_), params_);
+        poolAddressesProvider_.setLoanManagerImpl(params_);
         loanManager_ = poolAddressesProvider_.getLoanManager();
     }
 
@@ -95,14 +90,13 @@ contract DeployPool is BaseScript {
         broadcast(governor)
         returns (address withdrawalManager_)
     {
-        address withdrawalManagerImpl_ = address(new WithdrawalManager(poolAddressesProvider_));
         bytes memory params_ = abi.encodeWithSelector(
             WithdrawalManager.initialize.selector,
             address(poolAddressesProvider_),
             7 days, // cycle duration
             3 days // window duration
         );
-        poolAddressesProvider_.setWithdrawalManagerImpl(withdrawalManagerImpl_, params_);
+        poolAddressesProvider_.setWithdrawalManagerImpl(params_);
         withdrawalManager_ = poolAddressesProvider_.getWithdrawalManager();
     }
 }

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -159,7 +159,6 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         internal
         returns (IPoolConfigurator poolConfigurator_)
     {
-        address poolConfiguratorImpl_ = address(new PoolConfigurator(poolAddressesProvider_));
         bytes memory params_ = abi.encodeWithSelector(
             IPoolConfigurator.initialize.selector,
             address(poolAddressesProvider_),
@@ -169,7 +168,8 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
             defaults.POOL_SYMBOL()
         );
 
-        poolAddressesProvider_.setPoolConfiguratorImpl(poolConfiguratorImpl_, params_);
+        poolAddressesProvider_.setPoolConfiguratorImpl(params_);
+
         poolConfigurator_ = IPoolConfigurator(poolAddressesProvider_.getPoolConfigurator());
 
         poolConfigurator_.setPoolLimit(defaults.POOL_LIMIT());
@@ -190,15 +190,13 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         internal
         returns (IWithdrawalManager withdrawalManager_)
     {
-        address withdrawalManagerImpl_ = address(new WithdrawalManager(poolAddressesProvider_));
-
         bytes memory params = abi.encodeWithSelector(
             IWithdrawalManager.initialize.selector,
             address(poolAddressesProvider_),
             defaults.CYCLE_DURATION(),
             defaults.WINDOW_DURATION()
         );
-        poolAddressesProvider_.setWithdrawalManagerImpl(withdrawalManagerImpl_, params);
+        poolAddressesProvider_.setWithdrawalManagerImpl(params);
         withdrawalManager_ = IWithdrawalManager(poolAddressesProvider_.getWithdrawalManager());
     }
 
@@ -210,11 +208,9 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         internal
         returns (ILoanManager loanManager_)
     {
-        address loanManagerImpl_ = address(new LoanManager(poolAddressesProvider_));
-
         bytes memory params = abi.encodeWithSelector(ILoanManager.initialize.selector, asset_);
 
-        poolAddressesProvider_.setLoanManagerImpl(loanManagerImpl_, params);
+        poolAddressesProvider_.setLoanManagerImpl(params);
         loanManager_ = ILoanManager(poolAddressesProvider_.getLoanManager());
     }
 

--- a/tests/integration/shared/pool-configurator/initialize.t.sol
+++ b/tests/integration/shared/pool-configurator/initialize.t.sol
@@ -25,8 +25,7 @@ abstract contract Initialize_Integration_Shared_Test is PoolConfigurator_Integra
         internal
         returns (IPoolConfigurator poolConfigurator_)
     {
-        address poolConfiguratorImpl_ = address(new PoolConfigurator(poolAddressesProvider_));
-        poolAddressesProvider_.setPoolConfiguratorImpl(poolConfiguratorImpl_, bytes(""));
+        poolAddressesProvider_.setPoolConfiguratorImpl(bytes(""));
         poolConfigurator_ = IPoolConfigurator(poolAddressesProvider_.getPoolConfigurator());
     }
 }

--- a/tests/unit/concrete/loan-manager/initialize/initialize.t.sol
+++ b/tests/unit/concrete/loan-manager/initialize/initialize.t.sol
@@ -23,10 +23,9 @@ contract Initialize_LoanManager_Unit_Concrete_Test is LoanManager_Unit_Shared_Te
     }
 
     function test_initialize_RevertWhen_AssetZeroAddress() external {
-        address loanManagerImpl_ = address(new LoanManager(poolAddressesProvider));
         bytes memory params = abi.encodeWithSelector(ILoanManager.initialize.selector, address(0));
         vm.expectRevert(abi.encodeWithSelector(Errors.LoanManager_AssetZeroAddress.selector));
-        poolAddressesProvider.setLoanManagerImpl(loanManagerImpl_, params);
+        poolAddressesProvider.setLoanManagerImpl(params);
     }
 
     function test_initialize() external whenAssetNotZeroAddress {

--- a/tests/unit/concrete/pool-addresses-provider/set-loan-manager-impl/setLoanManagerImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-loan-manager-impl/setLoanManagerImpl.t.sol
@@ -26,8 +26,9 @@ contract SetLoanManagerImpl_PoolAddressesProvider_Unit_Concrete_Test is PoolAddr
     }
 
     function test_SetLoanManagerImpl() external whenCallerGovernor {
-        vm.expectEmit(address(poolAddressesProvider));
-        emit LoanManagerUpdated(address(0), _params.newLoanManager);
+        vm.expectEmit(false, false, false, false, address(poolAddressesProvider));
+        emit LoanManagerUpdated(address(0), address(0));
+
         setDefaultLoanManagerImpl();
     }
 }

--- a/tests/unit/concrete/pool-addresses-provider/set-pool-configurator-impl/setPoolConfiguratorImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-pool-configurator-impl/setPoolConfiguratorImpl.t.sol
@@ -25,8 +25,9 @@ contract SetPoolConfiguratorImpl_PoolAddressesProvider_Unit_Concrete_Test is Poo
     }
 
     function test_SetPoolConfiguratorImpl() external whenCallerGovernor {
-        vm.expectEmit(address(poolAddressesProvider));
-        emit PoolConfiguratorUpdated(address(0), _params.newPoolConfigurator);
+        vm.expectEmit(false, false, false, false, address(poolAddressesProvider));
+        emit PoolConfiguratorUpdated(address(0), address(0));
+
         setDefaultPoolConfiguratorImpl();
     }
 }

--- a/tests/unit/concrete/pool-addresses-provider/set-withdrawal-manager-impl/setWithdrawalManagerImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-withdrawal-manager-impl/setWithdrawalManagerImpl.t.sol
@@ -22,8 +22,9 @@ contract SetWithdrawalManagerImpl_PoolAddressesProvider_Unit_Concrete_Test is Po
     }
 
     function test_SetWithdrawalManagerImpl() external whenCallerGovernor {
-        vm.expectEmit(address(poolAddressesProvider));
-        emit WithdrawalManagerUpdated(address(0), _params.newWithdrawalManager);
+        vm.expectEmit(false, false, false, false, address(poolAddressesProvider));
+        emit WithdrawalManagerUpdated(address(0), address(0));
+
         setDefaultWithdrawalManagerImpl();
     }
 }

--- a/tests/unit/shared/pool-addresses-provider/PoolAddressesProvider.t.sol
+++ b/tests/unit/shared/pool-addresses-provider/PoolAddressesProvider.t.sol
@@ -22,9 +22,6 @@ abstract contract PoolAddressesProvider_Unit_Shared_Test is Base_Test {
         address newImplementationAddress;
         string poolName;
         string poolSymbol;
-        address newWithdrawalManager;
-        address newLoanManager;
-        address newPoolConfigurator;
         address newIsleGlobals;
         uint64 windowDuration;
         uint64 cycleDuration;
@@ -53,10 +50,6 @@ abstract contract PoolAddressesProvider_Unit_Shared_Test is Base_Test {
         // Deploy with create2 so we can precompute the deployment address
         changePrank(users.governor);
 
-        _params.newWithdrawalManager =
-            address(new WithdrawalManager{ salt: "WithdrawalManager" }(poolAddressesProvider));
-        _params.newLoanManager = address(new LoanManager{ salt: "LoanManager" }(poolAddressesProvider));
-        _params.newPoolConfigurator = address(new PoolConfigurator{ salt: "PoolConfigurator" }(poolAddressesProvider));
         _params.newIsleGlobals =
             address(new UUPSProxy{ salt: "IsleGlobals" }(address(new IsleGlobals{ salt: "IsleGlobals" }()), ""));
     }
@@ -92,7 +85,7 @@ abstract contract PoolAddressesProvider_Unit_Shared_Test is Base_Test {
 
     function setDefaultLoanManagerImpl() internal {
         bytes memory params = abi.encodeWithSelector(ILoanManager.initialize.selector, address(usdc));
-        poolAddressesProvider.setLoanManagerImpl(_params.newLoanManager, params);
+        poolAddressesProvider.setLoanManagerImpl(params);
     }
 
     function setDefaultWithdrawalManagerImpl() internal {
@@ -102,8 +95,7 @@ abstract contract PoolAddressesProvider_Unit_Shared_Test is Base_Test {
             _params.cycleDuration,
             _params.windowDuration
         );
-
-        poolAddressesProvider.setWithdrawalManagerImpl(_params.newWithdrawalManager, params);
+        poolAddressesProvider.setWithdrawalManagerImpl(params);
     }
 
     function setDefaultPoolConfiguratorImpl() internal {
@@ -115,8 +107,7 @@ abstract contract PoolAddressesProvider_Unit_Shared_Test is Base_Test {
             _params.poolSymbol,
             _params.poolName
         );
-
-        poolAddressesProvider.setPoolConfiguratorImpl(_params.newPoolConfigurator, params_);
+        poolAddressesProvider.setPoolConfiguratorImpl(params_);
     }
 
     function setDefaultIsleGlobals() internal {


### PR DESCRIPTION
# Summary
Initialization Front-Running Vulnerability in _updateImpl() Function

Issue: https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=97#ecb7fc6155344e2ba6814426280af368

# Description
The `_updateImpl()` function in PoolAddressesProvider.sol exposes the intention of the admin to initialize proxyAddress. Since the initialization process in TransparentUpgradeableProxy contracts is accessible to any caller, an attacker could potentially front-run the initialization. This issue is not considered to be of a higher severity because the contract provides the capability to create the proxy and initialize it within the same transaction, which is the recommended method to mitigate this issue.

# Fix
We make the proxy creation and initialization occur within the same transaction.

# Verification
- Run tests
   `SetLoanManagerImpl_PoolAddressesProvider_Unit_Concrete_Test `
   `SetPoolConfiguratorImpl_PoolAddressesProvider_Unit_Concrete_Test `
   `SetWithdrawalManagerImpl_PoolAddressesProvider_Unit_Concrete_Test `