### PR TITLE
fix: restrict solidity version to 0.8.19

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,7 @@
     "extends": "solhint:recommended",
     "rules": {
         "code-complexity": ["error", 8],
-        "compiler-version": ["error", ">=0.8.19"],
+        "compiler-version": ["error", "0.8.19"],
         "func-name-mixedcase": "off",
         "func-visibility": ["error", { "ignoreConstructors": true }],
         "max-line-length": ["error", 120],

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { ERC20, IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/contracts/PoolAddressesProvider.sol
+++ b/contracts/PoolAddressesProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import {
     ITransparentUpgradeableProxy,

--- a/contracts/WithdrawalManager.sol
+++ b/contracts/WithdrawalManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/WithdrawalManagerStorage.sol
+++ b/contracts/WithdrawalManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "./libraries/types/DataTypes.sol";
 import { IWithdrawalManagerStorage } from "./interfaces/IWithdrawalManagerStorage.sol";

--- a/contracts/abstracts/Governable.sol
+++ b/contracts/abstracts/Governable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { IGovernable } from "../interfaces/IGovernable.sol";
 import { Errors } from "../libraries/Errors.sol";

--- a/contracts/interfaces/IGovernable.sol
+++ b/contracts/interfaces/IGovernable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 /// @title IGovernable
 /// @notice Contract module that provides a basic access control mechanism, with a governor that can be

--- a/contracts/interfaces/ILoanManager.sol
+++ b/contracts/interfaces/ILoanManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Loan } from "../libraries/types/DataTypes.sol";
 

--- a/contracts/interfaces/ILoanManagerEvents.sol
+++ b/contracts/interfaces/ILoanManagerEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 interface ILoanManagerEvents {
     /// @notice Emitted when the loan manager is initialized.

--- a/contracts/interfaces/ILoanManagerStorage.sol
+++ b/contracts/interfaces/ILoanManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 interface ILoanManagerStorage {
     /// @notice Gets the asset used for the protocol.

--- a/contracts/interfaces/IPoolAddressesProvider.sol
+++ b/contracts/interfaces/IPoolAddressesProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 /// @title IPoolAddressesProvider
 /// @notice Defines the basic interface for a Pool Addresses Provider.

--- a/contracts/interfaces/IWithdrawalManager.sol
+++ b/contracts/interfaces/IWithdrawalManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "../libraries/types/DataTypes.sol";
 

--- a/contracts/interfaces/IWithdrawalManagerStorage.sol
+++ b/contracts/interfaces/IWithdrawalManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 interface IWithdrawalManagerStorage {
     /// @notice Gets the id of the latest config.

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 library Errors {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/libraries/PoolDeployer.sol
+++ b/contracts/libraries/PoolDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool } from "../Pool.sol";
 

--- a/contracts/libraries/types/DataTypes.sol
+++ b/contracts/libraries/types/DataTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 /// @notice Namespace for the structs used in {PoolConfigurator}
 library PoolConfigurator {

--- a/contracts/libraries/upgradability/UUPSProxy.sol
+++ b/contracts/libraries/upgradability/UUPSProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/contracts/libraries/upgradability/VersionedInitializable.sol
+++ b/contracts/libraries/upgradability/VersionedInitializable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 /**
  * @title VersionedInitializable

--- a/scripts/Base.s.sol
+++ b/scripts/Base.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Script } from "@forge-std/Script.sol";
 

--- a/scripts/DeployERC20Mint.s.sol
+++ b/scripts/DeployERC20Mint.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/scripts/DeployGlobals.s.sol
+++ b/scripts/DeployGlobals.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { IsleGlobals } from "../contracts/IsleGlobals.sol";
 

--- a/scripts/DeployPool.s.sol
+++ b/scripts/DeployPool.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { UUPSProxy } from "../contracts/libraries/upgradability/UUPSProxy.sol";
 

--- a/scripts/DeployReceivable.s.sol
+++ b/scripts/DeployReceivable.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Receivable } from "../contracts/Receivable.sol";
 

--- a/scripts/GetBalance.s.sol
+++ b/scripts/GetBalance.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { console2 } from "@forge-std/console2.sol";
 

--- a/scripts/Init.s.sol
+++ b/scripts/Init.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Solarray } from "solarray/Solarray.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/scripts/contracts/ERC20Mint.sol
+++ b/scripts/contracts/ERC20Mint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/scripts/createLoan.s.sol
+++ b/scripts/createLoan.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@forge-std/console2.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/scripts/mintIsleUSD.s.sol
+++ b/scripts/mintIsleUSD.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { BaseScript } from "./Base.s.sol";
 

--- a/scripts/repayLoan.s.sol
+++ b/scripts/repayLoan.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@forge-std/console2.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/scripts/setReceivableAsset.s.sol
+++ b/scripts/setReceivableAsset.s.sol
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;

--- a/scripts/setVault.s.sol
+++ b/scripts/setVault.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@forge-std/console2.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/scripts/updateAccounting.s.sol
+++ b/scripts/updateAccounting.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@forge-std/console2.sol";
 

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { StdCheats } from "@forge-std/StdCheats.sol";
 import { console } from "@forge-std/console.sol";

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { StdCheats } from "@forge-std/StdCheats.sol";
 

--- a/tests/integration/concrete/loan-manager/LoanManager.t.sol
+++ b/tests/integration/concrete/loan-manager/LoanManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Integration_Test } from "../../Integration.t.sol";
 

--- a/tests/integration/concrete/loan-manager/accrued-interest/accruedInterest.t.sol
+++ b/tests/integration/concrete/loan-manager/accrued-interest/accruedInterest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager_Integration_Concrete_Test } from "../LoanManager.t.sol";
 import { LoanManager_Integration_Shared_Test } from "../../../shared/loan-manager/LoanManager.t.sol";

--- a/tests/integration/concrete/loan-manager/assets-under-management/assetsUnderManagement.t.sol
+++ b/tests/integration/concrete/loan-manager/assets-under-management/assetsUnderManagement.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager_Integration_Concrete_Test } from "../LoanManager.t.sol";
 import { LoanManager_Integration_Shared_Test } from "../../../shared/loan-manager/LoanManager.t.sol";

--- a/tests/integration/concrete/loan-manager/fund-loan/fundLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/fund-loan/fundLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/get-loan-info/getLoanInfo.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-info/getLoanInfo.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Loan } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/loan-manager/get-loan-payment-breakdown/getLoanPaymentBreakdown.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-payment-breakdown/getLoanPaymentBreakdown.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager_Integration_Concrete_Test } from "../LoanManager.t.sol";
 import { LoanManager_Integration_Shared_Test } from "../../../shared/loan-manager/LoanManager.t.sol";

--- a/tests/integration/concrete/loan-manager/get-loan-payment-detailed-breakdown/getLoanPaymentDetailedBreakdown.t.sol
+++ b/tests/integration/concrete/loan-manager/get-loan-payment-detailed-breakdown/getLoanPaymentDetailedBreakdown.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager_Integration_Concrete_Test } from "../LoanManager.t.sol";
 import { LoanManager_Integration_Shared_Test } from "../../../shared/loan-manager/LoanManager.t.sol";

--- a/tests/integration/concrete/loan-manager/impair-loan/impairLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/impair-loan/impairLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/remove-loan-impairment/removeLoanImpairment.t.sol
+++ b/tests/integration/concrete/loan-manager/remove-loan-impairment/removeLoanImpairment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/repay-loan/repayLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/tests/integration/concrete/loan-manager/request-loan/requestLoan.t.sol
+++ b/tests/integration/concrete/loan-manager/request-loan/requestLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
+++ b/tests/integration/concrete/loan-manager/trigger-default/triggerDefault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/update-accounting/updateAccounting.t.sol
+++ b/tests/integration/concrete/loan-manager/update-accounting/updateAccounting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
+++ b/tests/integration/concrete/loan-manager/withdraw-funds/withdrawFunds.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/tests/integration/concrete/pool-configurator/deposit-cover/depositCover.t.sol
+++ b/tests/integration/concrete/pool-configurator/deposit-cover/depositCover.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/has-sufficient-cover/hasSufficientCover.t.sol
+++ b/tests/integration/concrete/pool-configurator/has-sufficient-cover/hasSufficientCover.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/initialize/initialize.t.sol
+++ b/tests/integration/concrete/pool-configurator/initialize/initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/max-deposit/maxDeposit.t.sol
+++ b/tests/integration/concrete/pool-configurator/max-deposit/maxDeposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/max-mint/maxMint.t.sol
+++ b/tests/integration/concrete/pool-configurator/max-mint/maxMint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/max-redeem/maxRedeem.t.sol
+++ b/tests/integration/concrete/pool-configurator/max-redeem/maxRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/preview-redeem/previewRedeem.t.sol
+++ b/tests/integration/concrete/pool-configurator/preview-redeem/previewRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/process-redeem/processRedeem.t.sol
+++ b/tests/integration/concrete/pool-configurator/process-redeem/processRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/remove-shares/removeShares.t.sol
+++ b/tests/integration/concrete/pool-configurator/remove-shares/removeShares.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/request-funds/requestFunds.t.sol
+++ b/tests/integration/concrete/pool-configurator/request-funds/requestFunds.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/tests/integration/concrete/pool-configurator/request-redeem/requestRedeem.t.sol
+++ b/tests/integration/concrete/pool-configurator/request-redeem/requestRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/set-max-cover-liquidation/setMaxCoverLiquidation.t.sol
+++ b/tests/integration/concrete/pool-configurator/set-max-cover-liquidation/setMaxCoverLiquidation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/set-min-cover/setMinCover.t.sol
+++ b/tests/integration/concrete/pool-configurator/set-min-cover/setMinCover.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/set-pool-limit/setPoolLimit.t.sol
+++ b/tests/integration/concrete/pool-configurator/set-pool-limit/setPoolLimit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/total-assets/totalAssets.t.sol
+++ b/tests/integration/concrete/pool-configurator/total-assets/totalAssets.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/transfer-admin/transferAdmin.t.sol
+++ b/tests/integration/concrete/pool-configurator/transfer-admin/transferAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/trigger-default/triggerDefault.t.sol
+++ b/tests/integration/concrete/pool-configurator/trigger-default/triggerDefault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool-configurator/unrealized-losses/unrealizedLosses.t.sol
+++ b/tests/integration/concrete/pool-configurator/unrealized-losses/unrealizedLosses.t.sol
@@ -1,1 +1,1 @@
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;

--- a/tests/integration/concrete/pool-configurator/withdraw-cover/withdrawCover.t.sol
+++ b/tests/integration/concrete/pool-configurator/withdraw-cover/withdrawCover.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/Pool.t.sol
+++ b/tests/integration/concrete/pool/Pool.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Integration_Test } from "../../Integration.t.sol";
 

--- a/tests/integration/concrete/pool/asset/asset.t.sol
+++ b/tests/integration/concrete/pool/asset/asset.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/balance-of-assets/balanceOfAssets.t.sol
+++ b/tests/integration/concrete/pool/balance-of-assets/balanceOfAssets.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/constructor/constructor.t.sol
+++ b/tests/integration/concrete/pool/constructor/constructor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/convert-to/convertTo.t.sol
+++ b/tests/integration/concrete/pool/convert-to/convertTo.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/decimals/decimals.t.sol
+++ b/tests/integration/concrete/pool/decimals/decimals.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/deposit-with-permit/depositWithPermit.t.sol
+++ b/tests/integration/concrete/pool/deposit-with-permit/depositWithPermit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/tests/integration/concrete/pool/deposit/deposit.t.sol
+++ b/tests/integration/concrete/pool/deposit/deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/tests/integration/concrete/pool/max-deposit/maxDeposit.t.sol
+++ b/tests/integration/concrete/pool/max-deposit/maxDeposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/max-mint/maxMint.t.sol
+++ b/tests/integration/concrete/pool/max-mint/maxMint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "../../../shared/pool/Pool.t.sol";
 

--- a/tests/integration/concrete/pool/max-redeem/maxRedeem.t.sol
+++ b/tests/integration/concrete/pool/max-redeem/maxRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/max-withdraw/maxWithdraw.t.sol
+++ b/tests/integration/concrete/pool/max-withdraw/maxWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/mint-with-permit/mintWithPermit.t.sol
+++ b/tests/integration/concrete/pool/mint-with-permit/mintWithPermit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/tests/integration/concrete/pool/mint/mint.t.sol
+++ b/tests/integration/concrete/pool/mint/mint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/tests/integration/concrete/pool/preview-redeem/previewRedeem.t.sol
+++ b/tests/integration/concrete/pool/preview-redeem/previewRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/preview-withdraw/previewWithdraw.t.sol
+++ b/tests/integration/concrete/pool/preview-withdraw/previewWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/redeem/redeem.t.sol
+++ b/tests/integration/concrete/pool/redeem/redeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/remove-shares/removeShares.t.sol
+++ b/tests/integration/concrete/pool/remove-shares/removeShares.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool } from "contracts/Pool.sol";
 

--- a/tests/integration/concrete/pool/request-redeem/requestRedeem.t.sol
+++ b/tests/integration/concrete/pool/request-redeem/requestRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/pool/total-assets/totalAssets.t.sol
+++ b/tests/integration/concrete/pool/total-assets/totalAssets.t.sol
@@ -1,5 +1,5 @@
 // SPDX-Lincense-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool } from "contracts/Pool.sol";
 

--- a/tests/integration/concrete/pool/unrealized-losses/unrealizedLosses.t.sol
+++ b/tests/integration/concrete/pool/unrealized-losses/unrealizedLosses.t.sol
@@ -1,1 +1,1 @@
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;

--- a/tests/integration/concrete/pool/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/pool/withdraw/withdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/add-shares/addShares.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/add-shares/addShares.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/constructor/constructor.sol
+++ b/tests/integration/concrete/withdrawal-manager/constructor/constructor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-config-at-id/getConfigAtId.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-config-at-id/getConfigAtId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-current-config/getCurrentConfig.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-current-config/getCurrentConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-current-cycle-id/getCurrentCycleId.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-current-cycle-id/getCurrentCycleId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-redeemable-amounts/getRedeemableAmounts.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-redeemable-amounts/getRedeemableAmounts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-window-at-id/getWindowAtId.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-window-at-id/getWindowAtId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/get-window-start/getWindowStart.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/get-window-start/getWindowStart.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/is-in-exit-window/isInExitWindow.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/is-in-exit-window/isInExitWindow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager_Integration_Shared_Test } from "../../../shared/withdrawal-manager/WithdrawalManager.t.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/locked-liquidity/lockedLiquidity.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/locked-liquidity/lockedLiquidity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager_Integration_Shared_Test } from "../../../shared/withdrawal-manager/WithdrawalManager.t.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/preview-redeem/previewRedeem.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/preview-redeem/previewRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { WithdrawalManager_Integration_Shared_Test } from "../../../shared/withdrawal-manager/WithdrawalManager.t.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/process-exit/processExit.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/process-exit/processExit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/remove-shares/removeShares.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/remove-shares/removeShares.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/concrete/withdrawal-manager/set-exit-config/setExitConfig.t.sol
+++ b/tests/integration/concrete/withdrawal-manager/set-exit-config/setExitConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/shared/loan-manager/LoanManager.t.sol
+++ b/tests/integration/shared/loan-manager/LoanManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/integration/shared/loan-manager/callable.t.sol
+++ b/tests/integration/shared/loan-manager/callable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager_Integration_Shared_Test } from "./LoanManager.t.sol";
 

--- a/tests/integration/shared/pool-configurator/PoolConfigurator.t.sol
+++ b/tests/integration/shared/pool-configurator/PoolConfigurator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/integration/shared/pool-configurator/initialize.t.sol
+++ b/tests/integration/shared/pool-configurator/initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { PoolConfigurator } from "contracts/PoolConfigurator.sol";
 import { IPoolAddressesProvider } from "contracts/interfaces/IPoolAddressesProvider.sol";

--- a/tests/integration/shared/pool/Pool.t.sol
+++ b/tests/integration/shared/pool/Pool.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Integration_Test } from "../../Integration.t.sol";
 

--- a/tests/integration/shared/pool/deposit.t.sol
+++ b/tests/integration/shared/pool/deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "./Pool.t.sol";
 

--- a/tests/integration/shared/pool/mint.t.sol
+++ b/tests/integration/shared/pool/mint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "./Pool.t.sol";
 

--- a/tests/integration/shared/pool/permit.t.sol
+++ b/tests/integration/shared/pool/permit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Pool_Integration_Shared_Test } from "./Pool.t.sol";
 

--- a/tests/integration/shared/withdrawal-manager/WithdrawalManager.t.sol
+++ b/tests/integration/shared/withdrawal-manager/WithdrawalManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/tests/mocks/LoanManagerHarness.sol
+++ b/tests/mocks/LoanManagerHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Loan } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/mocks/MintableERC20WithPermit.sol
+++ b/tests/mocks/MintableERC20WithPermit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 contract MintableERC20WithPermit {
     /*//////////////////////////////////////////////////////////////

--- a/tests/mocks/MockGovernable.sol
+++ b/tests/mocks/MockGovernable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Governable } from "contracts/abstracts/Governable.sol";
 

--- a/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.t.sol
+++ b/tests/unit/concrete/governable/transfer-governor.t/transferGovernor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/IsleGlobals.t.sol
+++ b/tests/unit/concrete/isle-globals/IsleGlobals.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/unit/concrete/isle-globals/get-revision.t.sol
+++ b/tests/unit/concrete/isle-globals/get-revision.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { VersionedInitializable } from "contracts/libraries/upgradability/VersionedInitializable.sol";
 import { IsleGlobals_Unit_Concrete_Test } from "./IsleGlobals.t.sol";

--- a/tests/unit/concrete/isle-globals/governor.t.sol
+++ b/tests/unit/concrete/isle-globals/governor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IsleGlobals_Unit_Concrete_Test } from "./IsleGlobals.t.sol";
 

--- a/tests/unit/concrete/isle-globals/initialize.t.sol
+++ b/tests/unit/concrete/isle-globals/initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IIsleGlobals } from "contracts/interfaces/IIsleGlobals.sol";
 

--- a/tests/unit/concrete/isle-globals/is-function-paused/isFunctionPaused.t.sol
+++ b/tests/unit/concrete/isle-globals/is-function-paused/isFunctionPaused.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IsleGlobals_Unit_Concrete_Test } from "../IsleGlobals.t.sol";
 

--- a/tests/unit/concrete/isle-globals/set-contract-paused/setContractPaused.t.sol
+++ b/tests/unit/concrete/isle-globals/set-contract-paused/setContractPaused.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-function-unpaused/setFunctionUnpaused.t.sol
+++ b/tests/unit/concrete/isle-globals/set-function-unpaused/setFunctionUnpaused.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-isle-vault/setIsleVault.t.sol
+++ b/tests/unit/concrete/isle-globals/set-isle-vault/setIsleVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-protocol-fee/setProtocolFee.t.sol
+++ b/tests/unit/concrete/isle-globals/set-protocol-fee/setProtocolFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-protocol-paused/setProtocolPaused.t.sol
+++ b/tests/unit/concrete/isle-globals/set-protocol-paused/setProtocolPaused.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-valid-collateral-asset/setValidCollateralAsset.t.sol
+++ b/tests/unit/concrete/isle-globals/set-valid-collateral-asset/setValidCollateralAsset.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-valid-pool-admin/setValidPoolAdmin.t.sol
+++ b/tests/unit/concrete/isle-globals/set-valid-pool-admin/setValidPoolAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/isle-globals/set-valid-pool-asset/setValidPoolAsset.t.sol
+++ b/tests/unit/concrete/isle-globals/set-valid-pool-asset/setValidPoolAsset.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/loan-manager/add-payment-to-list/addPaymentToList.sol
+++ b/tests/unit/concrete/loan-manager/add-payment-to-list/addPaymentToList.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/tests/unit/concrete/loan-manager/initialize/initialize.t.sol
+++ b/tests/unit/concrete/loan-manager/initialize/initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { LoanManager } from "contracts/LoanManager.sol";
 

--- a/tests/unit/concrete/loan-manager/remove-payment-from-list/removePaymentFromList.sol
+++ b/tests/unit/concrete/loan-manager/remove-payment-from-list/removePaymentFromList.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/constructor/constructor.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/constructor/constructor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-address-as-proxy/setAddressAsProxy.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-address-as-proxy/setAddressAsProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-address/setAddress.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-address/setAddress.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-isle-globals/setIsleGlobals.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-isle-globals/setIsleGlobals.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-loan-manager-impl/setLoanManagerImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-loan-manager-impl/setLoanManagerImpl.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-market-id/setMarketId.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-market-id/setMarketId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-pool-configurator-impl/setPoolConfiguratorImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-pool-configurator-impl/setPoolConfiguratorImpl.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-addresses-provider/set-withdrawal-manager-impl/setWithdrawalManagerImpl.t.sol
+++ b/tests/unit/concrete/pool-addresses-provider/set-withdrawal-manager-impl/setWithdrawalManagerImpl.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-configurator/set-admin-fee/setAdminFee.t.sol
+++ b/tests/unit/concrete/pool-configurator/set-admin-fee/setAdminFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-configurator/set-buyer/setBuyer.t.sol
+++ b/tests/unit/concrete/pool-configurator/set-buyer/setBuyer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-configurator/set-open-to-public/setOpenToPublic.t.sol
+++ b/tests/unit/concrete/pool-configurator/set-open-to-public/setOpenToPublic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-configurator/set-valid-lender/setValidLender.t.sol
+++ b/tests/unit/concrete/pool-configurator/set-valid-lender/setValidLender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/pool-configurator/set-valid-seller/setValidSeller.t.sol
+++ b/tests/unit/concrete/pool-configurator/set-valid-seller/setValidSeller.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Errors } from "contracts/libraries/Errors.sol";
 

--- a/tests/unit/concrete/receivable/create-receivable/createReceivable.t.sol
+++ b/tests/unit/concrete/receivable/create-receivable/createReceivable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC721EnumerableUpgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";

--- a/tests/unit/concrete/receivable/get-receivable-info-by-id/getReceivableInfoById.t.sol
+++ b/tests/unit/concrete/receivable/get-receivable-info-by-id/getReceivableInfoById.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Receivable_Unit_Shared_Test } from "../../../shared/receivable/Receivable.t.sol";
 

--- a/tests/unit/concrete/receivable/initialize/initialize.t.sol
+++ b/tests/unit/concrete/receivable/initialize/initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Receivable_Unit_Shared_Test } from "../../../shared/receivable/Receivable.t.sol";
 

--- a/tests/unit/shared/governable/Governable.t.sol
+++ b/tests/unit/shared/governable/Governable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/unit/shared/loan-manager/LoanManager.t.sol
+++ b/tests/unit/shared/loan-manager/LoanManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/unit/shared/loan-manager/payment-list.t.sol
+++ b/tests/unit/shared/loan-manager/payment-list.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/tests/unit/shared/pool-addresses-provider/PoolAddressesProvider.t.sol
+++ b/tests/unit/shared/pool-addresses-provider/PoolAddressesProvider.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/unit/shared/pool-configurator/PoolConfigurator.t.sol
+++ b/tests/unit/shared/pool-configurator/PoolConfigurator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/unit/shared/receivable/Receivable.t.sol
+++ b/tests/unit/shared/receivable/Receivable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/tests/utils/Assertions.sol
+++ b/tests/utils/Assertions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { PRBMathAssertions } from "@prb/math/test/Assertions.sol";

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 abstract contract Constants {
     uint8 public constant ASSET_DECIMALS = 6; // For USDC

--- a/tests/utils/Defaults.sol
+++ b/tests/utils/Defaults.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { Loan } from "contracts/libraries/types/DataTypes.sol";
 

--- a/tests/utils/Events.sol
+++ b/tests/utils/Events.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 abstract contract Events {
     // IsleGlobals events

--- a/tests/utils/Types.sol
+++ b/tests/utils/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { StdCheats } from "@forge-std/StdCheats.sol";
 

--- a/tests/utils/Utils.sol
+++ b/tests/utils/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import { MintableERC20WithPermit } from "../mocks/MintableERC20WithPermit.sol";
 import { Assertions } from "./Assertions.sol";


### PR DESCRIPTION
# Summary

The current contract uses floating pragma when specifying Solidity compiler version. It might lead to several issue, for example, there is no `PUSH0` opcode on most of the layer2, if the compiled bytecode generates such opcode, it will lead to error when deployment.

# Description

Detailed description can be found here in the [audit](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#cad03a75708d463da8a54cc4a59b117b) draft.

# Modification

Change all the solidity version from `^0.8.19` and `>=0.8.19` to `0.8.19`. Restrict the compiler version to `0.8.19` only.

# Verification

Run ALL the test to make sure it will not fail