### PR TITLE
fix parallel governor

### DIFF
--- a/contracts/Receivable.sol
+++ b/contracts/Receivable.sol
@@ -26,8 +26,6 @@ contract Receivable is
     UUPSUpgradeable,
     IReceivable
 {
-    address public governor;
-
     /*//////////////////////////////////////////////////////////////
                                MODIFIERS
     //////////////////////////////////////////////////////////////*/
@@ -46,12 +44,13 @@ contract Receivable is
 
     /// @inheritdoc IReceivable
     function initialize(address isleGlobal_) external override initializer {
+        if (isleGlobal_ == address(0)) revert Errors.ZeroAddress();
+        governor = IIsleGlobals(isleGlobal_).governor();
+        emit TransferGovernor({ oldGovernor: address(0), newGovernor: governor });
+
         __ERC721_init("Receivable", "RECV");
         __ERC721Enumerable_init();
         __ERC721Burnable_init();
-
-        governor = IIsleGlobals(isleGlobal_).governor();
-        emit TransferGovernor({ oldGovernor: address(0), newGovernor: governor });
     }
 
     /// @inheritdoc IReceivable

--- a/contracts/ReceivableStorage.sol
+++ b/contracts/ReceivableStorage.sol
@@ -3,7 +3,11 @@ pragma solidity 0.8.19;
 
 import { Receivable } from "./libraries/types/DataTypes.sol";
 
-contract ReceivableStorage {
+import { IReceivableStorage } from "./interfaces/IReceivableStorage.sol";
+
+contract ReceivableStorage is IReceivableStorage {
+    address public override governor;
+
     uint256 internal _tokenIdCounter;
 
     // The mapping of the token id to the receivable info

--- a/contracts/interfaces/IReceivable.sol
+++ b/contracts/interfaces/IReceivable.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.19;
 import { Receivable } from "../libraries/types/DataTypes.sol";
 
 import { IReceivableEvent } from "../interfaces/IReceivableEvent.sol";
-import { IGovernable } from "./IGovernable.sol";
 
 import { ReceivableStorage } from "../ReceivableStorage.sol";
 
-interface IReceivable is IGovernable, IReceivableEvent {
+interface IReceivable is IReceivableEvent {
+    /// @notice The address of the governor account or contract.
+    function governor() external view returns (address governor_);
+
     /*//////////////////////////////////////////////////////////////
                              UUPS FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/contracts/interfaces/IReceivable.sol
+++ b/contracts/interfaces/IReceivable.sol
@@ -4,13 +4,11 @@ pragma solidity 0.8.19;
 import { Receivable } from "../libraries/types/DataTypes.sol";
 
 import { IReceivableEvent } from "../interfaces/IReceivableEvent.sol";
+import { IReceivableStorage } from "../interfaces/IReceivableStorage.sol";
 
 import { ReceivableStorage } from "../ReceivableStorage.sol";
 
-interface IReceivable is IReceivableEvent {
-    /// @notice The address of the governor account or contract.
-    function governor() external view returns (address governor_);
-
+interface IReceivable is IReceivableEvent, IReceivableStorage {
     /*//////////////////////////////////////////////////////////////
                              UUPS FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/contracts/interfaces/IReceivableEvent.sol
+++ b/contracts/interfaces/IReceivableEvent.sol
@@ -19,4 +19,9 @@ interface IReceivableEvent {
     /// @notice Emitted when burn a receivable.
     /// @param tokenId_ The id of the receivable.
     event AssetBurned(uint256 indexed tokenId_);
+
+    /// @notice Emitted when the governor is transferred.
+    /// @param oldGovernor The address of the old governor.
+    /// @param newGovernor The address of the new governor.
+    event TransferGovernor(address indexed oldGovernor, address indexed newGovernor);
 }

--- a/contracts/interfaces/IReceivableStorage.sol
+++ b/contracts/interfaces/IReceivableStorage.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+interface IReceivableStorage {
+    /// @notice Returns the addres of the governor.
+    /// @return governor_ The address of the governor.
+    function governor() external view returns (address governor_);
+}

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -30,6 +30,9 @@ library Errors {
     /// @notice Thrown when pool addresses provider is set to 0.
     error AddressesProviderZeroAddress();
 
+    /// @notice Thrown when the address is zero address.
+    error ZeroAddress();
+
     /*//////////////////////////////////////////////////////////////
                            POOL CONFIGURATOR
     //////////////////////////////////////////////////////////////*/

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -113,8 +113,8 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
         changePrank(users.governor);
 
         // Deploy globals and receivable
-        receivable = deployReceivable();
         isleGlobals = deployGlobals();
+        receivable = deployReceivable(isleGlobals);
 
         // Deploy pool side contracts
         poolAddressesProvider = deployPoolAddressesProvider(isleGlobals);
@@ -140,10 +140,10 @@ abstract contract Base_Test is StdCheats, Events, Constants, Utils {
     }
 
     /// @dev Deploy receivable as an UUPS proxy
-    function deployReceivable() internal returns (IReceivable receivable_) {
+    function deployReceivable(IIsleGlobals isleGlobals_) internal returns (IReceivable receivable_) {
         // notice here we use Receivable instead of its interface IReceivable, since we want to call function
         receivable_ = Receivable(address(new UUPSProxy(address(new Receivable()), "")));
-        receivable_.initialize(users.governor);
+        receivable_.initialize(address(isleGlobals_));
     }
 
     /// @dev Deploy pool addresses provider

--- a/tests/unit/concrete/receivable/initialize/initialize.t.sol
+++ b/tests/unit/concrete/receivable/initialize/initialize.t.sol
@@ -13,7 +13,7 @@ contract Initialize_Receivable_Unit_Concrete_Test is Receivable_Unit_Shared_Test
     }
 
     function test_Initialize() public {
-        IReceivable receivable_ = deployReceivable();
+        IReceivable receivable_ = deployReceivable(isleGlobals);
         assertEq(receivable_.governor(), users.governor);
     }
 }

--- a/tests/unit/concrete/receivable/initialize/initialize.t.sol
+++ b/tests/unit/concrete/receivable/initialize/initialize.t.sol
@@ -5,11 +5,20 @@ import { Receivable_Unit_Shared_Test } from "../../../shared/receivable/Receivab
 
 import { IReceivable } from "contracts/interfaces/IReceivable.sol";
 
-import { Receivable } from "contracts/libraries/types/DataTypes.sol";
+import { Receivable } from "contracts/Receivable.sol";
+import { UUPSProxy } from "contracts/libraries/upgradability/UUPSProxy.sol";
+import { Errors } from "contracts/libraries/Errors.sol";
 
 contract Initialize_Receivable_Unit_Concrete_Test is Receivable_Unit_Shared_Test {
     function setUp() public virtual override(Receivable_Unit_Shared_Test) {
         Receivable_Unit_Shared_Test.setUp();
+    }
+
+    function test_Initialize_RevertWhen_IsleGlobalZeroAddress() public {
+        IReceivable receivable_ = Receivable(address(new UUPSProxy(address(new Receivable()), "")));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ZeroAddress.selector));
+        receivable_.initialize(address(0));
     }
 
     function test_Initialize() public {

--- a/tests/unit/shared/receivable/Receivable.t.sol
+++ b/tests/unit/shared/receivable/Receivable.t.sol
@@ -20,7 +20,8 @@ abstract contract Receivable_Unit_Shared_Test is Base_Test {
 
     function deployAndLabelContract() internal {
         changePrank(users.governor);
-        receivable = deployReceivable();
+        isleGlobals = deployGlobals();
+        receivable = deployReceivable(isleGlobals);
     }
 
     modifier whenCallerPoolAdmin() {


### PR DESCRIPTION
# Summary
Parallel governor value in IsleGlobal and Receivable contract may result in two separate governor addresses

[Issue](https://www.notion.so/islelabs/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#3bc60f59c395425fa6ef1c8065df04e1)

# Description
The governor address for the Isle protocol has the authority to make changes and modify settings which are critical to the protocol’s day to day operations. This address is stored in both the Receivable and IsleGlobal contract however, since the address is set twice (once for each contract), this may cause inconsistent addresses resulting in inconsistent data if one were to be changed but not the other due to human error or some other reason.

# Fix
Provide IsleGlobal address to the constructor of Receivable, this make the governor can be obtained from IsleGlobal.

# Verification
- Run tests
   `Initialize_Receivable_Unit_Concrete_Test`