### PR TITLE
Fix: proxy upgrade script

### DIFF
--- a/scripts/Base.s.sol
+++ b/scripts/Base.s.sol
@@ -120,12 +120,12 @@ abstract contract BaseScript is Script {
     }
 
     function deployGlobals() internal broadcast(deployer) returns (IsleGlobals globals_) {
-        globals_ = IsleGlobals(address(new UUPSProxy(address(new IsleGlobals()), "")));
-        globals_.initialize(governor);
+        bytes memory initializeData_ = abi.encodeWithSignature("initialize(address)", governor);
+        globals_ = IsleGlobals(address(new UUPSProxy(address(new IsleGlobals()), initializeData_)));
     }
 
     function deployReceivable(address isleGlobal_) internal broadcast(deployer) returns (Receivable receivable_) {
-        receivable_ = Receivable(address(new UUPSProxy(address(new Receivable()), "")));
-        receivable_.initialize(isleGlobal_);
+        bytes memory initializeData_ = abi.encodeWithSignature("initialize(address)", isleGlobal_);
+        receivable_ = Receivable(address(new UUPSProxy(address(new Receivable()), initializeData_)));
     }
 }


### PR DESCRIPTION
# Summary
In the proxy upgrade, the process should be done in atomic transaction, or the MEV might be able to initialize the implementation contract, setting important variables. We examine our script, to make sure all the operation is done within the same transaction.

# Description
In the foundry script, it should be considered as 2 transaction:

```
proxy.upgradeTo(implementation)
proxy.initialize()
```
To prevent potential malicious initialization, we should use this instead:
```
bytes memory data = abi.encodeWithSignature("initialize(arg1,arg2)",arg1, arg2);
proxy.upgradeToAndCall(implementation, data);
```

# Modification

I change the base script to ensure atomic proxy upgrade and initialization as described above.

# Verification

Manual review as there is test case for script.