### PR TITLE
Fix: add upgradeable lock

### DIFF
--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 import { Errors } from "./libraries/Errors.sol";
 import { VersionedInitializable } from "./libraries/upgradability/VersionedInitializable.sol";
+import { ReentrancyGuardUpgradeable } from "./libraries/ReentrancyGuard.sol";
 import { Receivable, Loan } from "./libraries/types/DataTypes.sol";
 
 import { IIsleGlobals } from "./interfaces/IIsleGlobals.sol";
@@ -19,7 +19,13 @@ import { IReceivable } from "./interfaces/IReceivable.sol";
 
 import { LoanManagerStorage } from "./LoanManagerStorage.sol";
 
-contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, ReentrancyGuard, VersionedInitializable {
+contract LoanManager is
+    ILoanManager,
+    IERC721Receiver,
+    LoanManagerStorage,
+    VersionedInitializable,
+    ReentrancyGuardUpgradeable
+{
     uint256 public constant LOAN_MANAGER_REVISION = 0x1;
 
     uint256 public constant HUNDRED_PERCENT = 1e6; // 100.0000%
@@ -48,6 +54,7 @@ contract LoanManager is ILoanManager, IERC721Receiver, LoanManagerStorage, Reent
         if (asset_ == address(0)) {
             revert Errors.LoanManager_AssetZeroAddress();
         }
+        __ReentrancyGuard_init();
         emit Initialized({ poolAddressesProvider_: address(ADDRESSES_PROVIDER), asset_: asset = asset_ });
     }
 

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -36,6 +36,9 @@ library Errors {
     /// @notice Thrown when the address is zero address.
     error ZeroAddress();
 
+    /// @notice Thrown when a reentrancy lock is already set.
+    error ReentrancyGuardReentrantCall();
+
     /*//////////////////////////////////////////////////////////////
                            POOL CONFIGURATOR
     //////////////////////////////////////////////////////////////*/

--- a/contracts/libraries/ReentrancyGuard.sol
+++ b/contracts/libraries/ReentrancyGuard.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { Errors } from "./Errors.sol";
+import { VersionedInitializable } from "./upgradability/VersionedInitializable.sol";
+
+abstract contract ReentrancyGuardUpgradeable is VersionedInitializable {
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    struct ReentrancyGuardStorage {
+        uint256 _status;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ReentrancyGuard")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ReentrancyGuardStorageLocation =
+        0x9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00;
+
+    function _getReentrancyGuardStorage() private pure returns (ReentrancyGuardStorage storage $) {
+        assembly {
+            $.slot := ReentrancyGuardStorageLocation
+        }
+    }
+
+    function __ReentrancyGuard_init() internal onlyInitializing {
+        ReentrancyGuardStorage storage $ = _getReentrancyGuardStorage();
+        $._status = NOT_ENTERED;
+    }
+
+    modifier nonReentrant() {
+        ReentrancyGuardStorage storage $ = _getReentrancyGuardStorage();
+        // On the first call to nonReentrant, _status will be NOT_ENTERED
+        if ($._status == ENTERED) {
+            revert Errors.ReentrancyGuardReentrantCall();
+        }
+        $._status = ENTERED;
+        _;
+        $._status = NOT_ENTERED;
+    }
+}

--- a/contracts/libraries/upgradability/VersionedInitializable.sol
+++ b/contracts/libraries/upgradability/VersionedInitializable.sol
@@ -14,21 +14,33 @@ pragma solidity 0.8.19;
  * because this is not dealt with automatically as with constructors.
  */
 abstract contract VersionedInitializable {
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
+
     /**
      * @dev Indicates that the contract has been initialized.
      */
-    uint256 private lastInitializedRevision = 0;
-
-    /**
-     * @dev Indicates that the contract is in the process of being initialized.
-     */
-    bool private initializing;
+    struct VersionedInitializableStorage {
+        /**
+         * @dev Indicates the current contract version.
+         */
+        uint256 lastInitializedRevision;
+        /**
+         * @dev Indicates that the contract is in the process of being initialized.
+         */
+        bool initializing;
+    }
 
     /**
      * @dev Modifier to use in the initializer function of a contract.
      */
     modifier initializer() {
         uint256 revision = getRevision();
+
+        VersionedInitializableStorage storage $ = _getInitializableStorage();
+        uint256 lastInitializedRevision = $.lastInitializedRevision;
+        bool initializing = $.initializing;
+
         require(
             initializing || isConstructor() || revision > lastInitializedRevision,
             "Contract instance has already been initialized"
@@ -36,15 +48,23 @@ abstract contract VersionedInitializable {
 
         bool isTopLevelCall = !initializing;
         if (isTopLevelCall) {
-            initializing = true;
-            lastInitializedRevision = revision;
+            $.initializing = true;
+            $.lastInitializedRevision = revision;
         }
 
         _;
 
         if (isTopLevelCall) {
-            initializing = false;
+            $.initializing = false;
         }
+    }
+
+    /**
+     * @dev Modifier to use when a function is restricted to the initialization phase.
+     */
+    modifier onlyInitializing() {
+        require(_getInitializing(), "Already Initialized");
+        _;
     }
 
     /**
@@ -70,6 +90,20 @@ abstract contract VersionedInitializable {
             cs := extcodesize(address())
         }
         return cs == 0;
+    }
+
+    function _getInitializableStorage() private pure returns (VersionedInitializableStorage storage $) {
+        assembly {
+            $.slot := INITIALIZABLE_STORAGE
+        }
+    }
+
+    function _getLastInitializedRevision() internal view returns (uint256) {
+        return _getInitializableStorage().lastInitializedRevision;
+    }
+
+    function _getInitializing() internal view returns (bool) {
+        return _getInitializableStorage().initializing;
     }
 
     // Reserved storage space to allow for layout changes in the future.


### PR DESCRIPTION
# Summary
The original reentrancy guard is not upgradeable version, this PR adds an upgradeable reentrancy library for `LoanManager`.

# Description
The issue is described [here](https://www.notion.so/Smart-Contract-Audit-Draft-Response-v1-0-03839677f03540238c0d167fdeee2e7e?pvs=4#8c755fd88dd24ede8b59bb1090a4e34c).

# Modification
Add a new ReentrancyGuard library.

# Verification
Verified by running tests related to `LoanManager`.