### PR TITLE
ci: use default config for jobs and upgrade actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ concurrency:
     group: ${{github.workflow}}-${{github.ref}}
 
 env:
-    # FOUNDRY_PROFILE: "default"
+    FOUNDRY_PROFILE: "default"
     # API_KEY_INFURA: ${{ secrets.API_KEY_INFURA }}
     API_KEY_ALCHEMY: ${{ secrets.API_KEY_ALCHEMY }}
     API_KEY_ETHERSCAN: ${{ secrets.API_KEY_ETHERSCAN }}
@@ -23,7 +23,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v3"
+              uses: "actions/checkout@v4"
               with:
                   submodules: "recursive"
 
@@ -31,12 +31,12 @@ jobs:
               uses: "foundry-rs/foundry-toolchain@v1"
 
             - name: "Install Pnpm"
-              uses: "pnpm/action-setup@v2"
+              uses: "pnpm/action-setup@v4"
               with:
-                  version: "8"
+                  version: 9
 
             - name: "Install Node.js"
-              uses: "actions/setup-node@v3"
+              uses: "actions/setup-node@v4"
               with:
                   cache: "pnpm"
                   node-version: "lts/*"
@@ -56,7 +56,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v3"
+              uses: "actions/checkout@v4"
               with:
                   submodules: "recursive"
 
@@ -64,12 +64,12 @@ jobs:
               uses: "foundry-rs/foundry-toolchain@v1"
 
             - name: "Install Pnpm"
-              uses: "pnpm/action-setup@v2"
+              uses: "pnpm/action-setup@v4"
               with:
-                  version: "8"
+                  version: 9
 
             - name: "Install Node.js"
-              uses: "actions/setup-node@v3"
+              uses: "actions/setup-node@v4"
               with:
                   cache: "pnpm"
                   node-version: "lts/*"
@@ -84,10 +84,10 @@ jobs:
               run: "./shell/prepare-artifacts.sh"
 
             - name: "Build the test contracts"
-              run: "FOUNDRY_PROFILE=test-optimized forge build"
+              run: "forge build"
 
             - name: "Cache the build so that it can be re-used by the other jobs"
-              uses: "actions/cache/save@v3"
+              uses: "actions/cache/save@v4"
               with:
                   path: |
                       out
@@ -96,7 +96,7 @@ jobs:
                   key: "foundry-build-${{ github.sha }}"
 
             - name: "Store the contract artifacts in CI"
-              uses: "actions/upload-artifact@v3"
+              uses: "actions/upload-artifact@v4"
               with:
                   name: "contract-artifacts"
                   path: "artifacts"
@@ -110,7 +110,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v3"
+              uses: "actions/checkout@v4"
               with:
                   submodules: "recursive"
 
@@ -121,7 +121,7 @@ jobs:
               run: "forge config"
 
             - name: "Restore the cached build"
-              uses: "actions/cache/restore@v3"
+              uses: "actions/cache/restore@v4"
               with:
                   fail-on-cache-miss: true
                   key: "foundry-build-${{ github.sha }}"
@@ -137,7 +137,7 @@ jobs:
                   )" >> $GITHUB_ENV
 
             - name: "Run the tests against the optimized build"
-              run: "FOUNDRY_PROFILE=test-optimized forge test"
+              run: "forge test"
 
             - name: "Add test summary"
               run: |
@@ -149,7 +149,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v3"
+              uses: "actions/checkout@v4"
               with:
                   submodules: "recursive"
 
@@ -160,7 +160,7 @@ jobs:
               run: 'forge coverage --match-path "tests/{unit,integration}/**/*.sol" --report lcov --ir-minimum'
 
             - name: "Upload coverage report to Codecov"
-              uses: "codecov/codecov-action@v3"
+              uses: "codecov/codecov-action@v4"
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
               with:


### PR DESCRIPTION
## Changes
- Upgrade actions version
- Use default config for build and test job

## Note
`forge coverage` always re-compile the foundry project, so the cache of the build not working in this case.